### PR TITLE
Add X-Accel-Buffering header for SSE endpoint

### DIFF
--- a/src/gateways/stdioToSse.ts
+++ b/src/gateways/stdioToSse.ts
@@ -83,6 +83,9 @@ export async function stdioToSse(args: StdioToSseArgs) {
   app.get(ssePath, async (req, res) => {
     logger.info(`New SSE connection from ${req.ip}`)
 
+    // Set custom headers
+    res.setHeader('X-Accel-Buffering', 'no')
+
     const sseTransport = new SSEServerTransport(`${baseUrl}${messagePath}`, res)
     await server.connect(sseTransport)
 


### PR DESCRIPTION
Related to https://github.com/supercorp-ai/supergateway/issues/30

This header is critical for streaming protocols like SSE as it instructs Nginx to bypass its default buffering behavior and immediately forward each data chunk to the client. Without this header, Nginx buffers data until certain conditions are met, causing delays that break the real-time nature of SSE.
The header is Nginx-specific and won't affect other parts of the application or servers not using Nginx. Non-Nginx servers will simply ignore this header.