### PR TITLE
fix(stdioToSse): Ensure baseUrl is respected in SSE endpoint events

### DIFF
--- a/src/gateways/stdioToSse.ts
+++ b/src/gateways/stdioToSse.ts
@@ -111,33 +111,64 @@ export async function stdioToSse(args: StdioToSseArgs) {
       headers,
     })
 
-    const sseTransport = new SSEServerTransport(`${baseUrl}${messagePath}`, res)
+    const fullMessageEndpoint = baseUrl 
+      ? new URL(messagePath, baseUrl).href 
+      : messagePath
+
+    const responseMiddleware = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+      const originalWrite = res.write;
+      const originalEnd = res.end;
+
+      // @ts-ignore - Monkey patching the write method
+      res.write = function(chunk, encoding, callback) {
+        let data = chunk;
+        if (typeof chunk === 'string' && baseUrl && chunk.includes('event: endpoint\ndata: /')) {
+          data = chunk.replace(
+            /data: (\/[^\n]*)/g, 
+            (_, path) => `data: ${new URL(path, baseUrl).href}`
+          );
+        }
+        // @ts-ignore - Allow the original method to handle the correct types
+        return originalWrite.call(this, data, encoding, callback);
+      };
+
+      next();
+    };
+
+    if (baseUrl) {
+      responseMiddleware(req, res, () => {});
+    }
+
+    const sseTransport = new SSEServerTransport(fullMessageEndpoint, res)
     await server.connect(sseTransport)
 
     const sessionId = sseTransport.sessionId
     if (sessionId) {
       sessions[sessionId] = { transport: sseTransport, response: res }
+    
+      sseTransport.onmessage = (msg: JSONRPCMessage) => {
+        logger.info(`SSE → Child (session ${sessionId}): ${JSON.stringify(msg)}`)
+        child.stdin.write(JSON.stringify(msg) + '\n')
+      }
+    
+      sseTransport.onclose = () => {
+        logger.info(`SSE connection closed (session ${sessionId})`)
+        delete sessions[sessionId]
+      }
+    
+      sseTransport.onerror = (err) => {
+        logger.error(`SSE error (session ${sessionId}):`, err)
+        delete sessions[sessionId]
+      }
+    
+      req.on('close', () => {
+        logger.info(`Client disconnected (session ${sessionId})`)
+        delete sessions[sessionId]
+      })
+    } else {
+      logger.error(`No session ID was generated for the SSE connection`)
+      res.status(500).end('Failed to establish SSE connection')
     }
-
-    sseTransport.onmessage = (msg: JSONRPCMessage) => {
-      logger.info(`SSE → Child (session ${sessionId}): ${JSON.stringify(msg)}`)
-      child.stdin.write(JSON.stringify(msg) + '\n')
-    }
-
-    sseTransport.onclose = () => {
-      logger.info(`SSE connection closed (session ${sessionId})`)
-      delete sessions[sessionId]
-    }
-
-    sseTransport.onerror = (err) => {
-      logger.error(`SSE error (session ${sessionId}):`, err)
-      delete sessions[sessionId]
-    }
-
-    req.on('close', () => {
-      logger.info(`Client disconnected (session ${sessionId})`)
-      delete sessions[sessionId]
-    })
   })
 
   // @ts-ignore


### PR DESCRIPTION
Due to changes in the newer releases of the '@modelcontextprotocol/sdk' dependency, the --baseUrl argument wasn't reflecting in the data event message endpoint.

This proposed change ensures that SSE endpoint events include the full URL when a baseUrl 
is provided, such as 'https://example.com/message?sessionId=1234'.