### PR TITLE
Update README for streamable HTTP mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ npx -y supergateway --stdio "uvx mcp-server-git"
 - **`--stdio "command"`**: Command that runs an MCP server over stdio
 - **`--sse "https://mcp-server-ab71a6b2-cd55-49d0-adba-562bc85956e3.supermachine.app"`**: SSE URL to connect to (SSE→stdio mode)
 - **`--streamableHttp "https://mcp-server.example.com/mcp"`**: Streamable HTTP URL to connect to (StreamableHttp→stdio mode)
-- **`--outputTransport stdio | sse | ws`**: Output MCP transport (default: `sse` with `--stdio`, `stdio` with `--sse`)
+- **`--outputTransport stdio | sse | ws | streamableHttp`**: Output MCP transport (default: `sse` with `--stdio`, `stdio` with `--sse` or `--streamableHttp`)
 - **`--port 8000`**: Port to listen on (stdio→SSE or stdio→WS mode, default: `8000`)
 - **`--baseUrl "http://localhost:8000"`**: Base URL for SSE or WS clients (stdio→SSE mode; optional)
 - **`--ssePath "/sse"`**: Path for SSE subscriptions (stdio→SSE mode, default: `/sse`)
 - **`--messagePath "/message"`**: Path for messages (stdio→SSE or stdio→WS mode, default: `/message`)
+- **`--streamableHttpPath "/mcp"`**: Path for Streamable HTTP (stdio→Streamable HTTP mode, default: `/mcp`)
+- **`--stateful`**: Run stdio→Streamable HTTP in stateful mode
+- **`--sessionTimeout 60000`**: Session timeout in milliseconds (stateful stdio→Streamable HTTP mode only)
 - **`--header "x-user-id: 123"`**: Add one or more headers (stdio→SSE, SSE→stdio, or Streamable HTTP→stdio mode; can be used multiple times)
 - **`--oauth2Bearer "some-access-token"`**: Adds an `Authorization` header with the provided Bearer token
 - **`--logLevel debug | info | none`**: Controls logging level (default: `info`). Use `debug` for more verbose logs, `none` to suppress all logs.
@@ -75,6 +78,30 @@ npx -y supergateway \
     --oauth2Bearer "some-access-token" \
     --header "X-My-Header: another-header-value"
 ```
+
+## stdio → Streamable HTTP
+
+Expose an MCP stdio server as a Streamable HTTP server.
+
+### Stateless mode
+
+```bash
+npx -y supergateway \
+    --stdio "npx -y @modelcontextprotocol/server-filesystem ./my-folder" \
+    --outputTransport streamableHttp \
+    --port 8000
+```
+
+### Stateful mode
+
+```bash
+npx -y supergateway \
+    --stdio "npx -y @modelcontextprotocol/server-filesystem ./my-folder" \
+    --outputTransport streamableHttp --stateful \
+    --sessionTimeout 60000 --port 8000
+```
+
+The Streamable HTTP endpoint defaults to `http://localhost:8000/mcp` (configurable via `--streamableHttpPath`).
 
 ## stdio → WS
 


### PR DESCRIPTION
## Summary
- document `stdio` to streamable HTTP gateway (stateless and stateful)
- add documentation for `--stateful`, `--sessionTimeout`, `--streamableHttpPath`
- mention `streamableHttp` in `--outputTransport` options

## Testing
- `npm run build`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68584ddf36dc8322b56dbfa4dc565377