### PR TITLE
Fixed issue https://github.com/supercorp-ai/supergateway/issues/91

### DIFF
--- a/src/gateways/sseToStdio.ts
+++ b/src/gateways/sseToStdio.ts
@@ -12,6 +12,7 @@ import { z } from 'zod'
 import { getVersion } from '../lib/getVersion.js'
 import { Logger } from '../types.js'
 import { onSignals } from '../lib/onSignals.js'
+import { safeJsonStringify } from '../lib/jsonBuffer.js'
 
 export interface SseToStdioArgs {
   sseUrl: string
@@ -62,7 +63,7 @@ export async function sseToStdio(args: SseToStdioArgs) {
 
   logger.info(`  - sse: ${sseUrl}`)
   logger.info(
-    `  - Headers: ${Object.keys(headers).length ? JSON.stringify(headers) : '(none)'}`,
+    `  - Headers: ${Object.keys(headers).length ? safeJsonStringify(headers) : '(none)'}`,
   )
   logger.info('Connecting to SSE...')
 
@@ -174,7 +175,7 @@ export async function sseToStdio(args: SseToStdioArgs) {
             message: errorMsg,
           },
         })
-        process.stdout.write(JSON.stringify(errorResp) + '\n')
+        process.stdout.write(safeJsonStringify(errorResp) + '\n')
         return
       }
       const response = wrapResponse(
@@ -184,10 +185,10 @@ export async function sseToStdio(args: SseToStdioArgs) {
           : { result: { ...result } },
       )
       logger.info('Response:', response)
-      process.stdout.write(JSON.stringify(response) + '\n')
+      process.stdout.write(safeJsonStringify(response) + '\n')
     } else {
       logger.info('SSE → Stdio:', message)
-      process.stdout.write(JSON.stringify(message) + '\n')
+      process.stdout.write(safeJsonStringify(message) + '\n')
     }
   }
 

--- a/src/gateways/streamableHttpToStdio.ts
+++ b/src/gateways/streamableHttpToStdio.ts
@@ -13,6 +13,7 @@ import { z } from 'zod'
 import { getVersion } from '../lib/getVersion.js'
 import { Logger } from '../types.js'
 import { onSignals } from '../lib/onSignals.js'
+import { safeJsonStringify } from '../lib/jsonBuffer.js'
 
 export interface StreamableHttpToStdioArgs {
   streamableHttpUrl: string
@@ -63,7 +64,7 @@ export async function streamableHttpToStdio(args: StreamableHttpToStdioArgs) {
 
   logger.info(`  - streamableHttp: ${streamableHttpUrl}`)
   logger.info(
-    `  - Headers: ${Object.keys(headers).length ? JSON.stringify(headers) : '(none)'}`,
+    `  - Headers: ${Object.keys(headers).length ? safeJsonStringify(headers) : '(none)'}`,
   )
   logger.info('Connecting to Streamable HTTP...')
 
@@ -175,7 +176,7 @@ export async function streamableHttpToStdio(args: StreamableHttpToStdioArgs) {
             message: errorMsg,
           },
         })
-        process.stdout.write(JSON.stringify(errorResp) + '\n')
+        process.stdout.write(safeJsonStringify(errorResp) + '\n')
         return
       }
       const response = wrapResponse(
@@ -185,10 +186,10 @@ export async function streamableHttpToStdio(args: StreamableHttpToStdioArgs) {
           : { result: { ...result } },
       )
       logger.info('Response:', response)
-      process.stdout.write(JSON.stringify(response) + '\n')
+      process.stdout.write(safeJsonStringify(response) + '\n')
     } else {
       logger.info('Streamable HTTP → Stdio:', message)
-      process.stdout.write(JSON.stringify(message) + '\n')
+      process.stdout.write(safeJsonStringify(message) + '\n')
     }
   }
 

--- a/src/lib/jsonBuffer.ts
+++ b/src/lib/jsonBuffer.ts
@@ -1,0 +1,163 @@
+/**
+ * Safely stringify JSON by escaping Unicode line separators that can cause parsing issues.
+ * This prevents issues with U+2028 (Line Separator) and U+2029 (Paragraph Separator)
+ * characters that can break JSON parsing in some contexts.
+ */
+export function safeJsonStringify(value: any): string {
+  return JSON.stringify(value)
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
+}
+
+/**
+ * Safely parse JSON by first escaping any unescaped Unicode line separators.
+ * This handles cases where JSON contains raw U+2028 or U+2029 characters that
+ * would otherwise cause parsing to fail.
+ */
+export function safeJsonParse(text: string): any {
+  // First escape any unescaped Unicode line separators
+  const escapedText = text
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
+  return JSON.parse(escapedText)
+}
+
+/**
+ * Sanitize JSON object by escaping Unicode line separators in string values.
+ * This ensures the object can be safely stringified by standard JSON.stringify.
+ */
+export function sanitizeJsonObject(obj: any): any {
+  if (typeof obj === 'string') {
+    return obj.replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029')
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeJsonObject)
+  }
+  if (obj !== null && typeof obj === 'object') {
+    const sanitized: any = {}
+    for (const [key, value] of Object.entries(obj)) {
+      sanitized[sanitizeJsonObject(key)] = sanitizeJsonObject(value)
+    }
+    return sanitized
+  }
+  return obj
+}
+
+/**
+ * JsonBuffer handles streaming JSON parsing for large responses and mixed content.
+ * It can parse both line-based JSON (traditional) and large JSON objects without newlines.
+ * Non-JSON content (like npm logs) is silently ignored.
+ */
+export class JsonBuffer {
+  private buffer = ''
+  private onMessage: (message: any) => void
+  private onError: (error: string, rawData: string) => void
+
+  constructor(
+    onMessage: (message: any) => void,
+    onError: (error: string, rawData: string) => void,
+  ) {
+    this.onMessage = onMessage
+    this.onError = onError
+  }
+
+  addChunk(chunk: string) {
+    this.buffer += chunk
+    this.processBuffer()
+  }
+
+  private processBuffer() {
+    while (this.buffer.length > 0) {
+      // Try to extract complete JSON objects first (for large JSON without newlines)
+      const jsonObject = this.extractJsonObject()
+      if (jsonObject) {
+        this.tryParseAndUpdate(jsonObject.json, jsonObject.remaining)
+        continue
+      }
+
+      // Fall back to line-based processing
+      const line = this.extractLine()
+      if (!line) break
+
+      this.tryParseAndUpdate(line.content, line.remaining)
+    }
+  }
+
+  private extractJsonObject(): { json: string; remaining: string } | null {
+    const start = this.buffer.indexOf('{')
+    if (start === -1) return null
+
+    let braceCount = 0
+    let inString = false
+    let escaped = false
+
+    for (let i = start; i < this.buffer.length; i++) {
+      const char = this.buffer[i]
+
+      if (escaped) {
+        escaped = false
+        continue
+      }
+
+      if (char === '\\' && inString) {
+        escaped = true
+        continue
+      }
+
+      if (char === '"') {
+        inString = !inString
+        continue
+      }
+
+      if (!inString) {
+        if (char === '{') braceCount++
+        else if (char === '}') {
+          braceCount--
+          if (braceCount === 0) {
+            return {
+              json: this.buffer.slice(start, i + 1),
+              remaining: this.buffer.slice(i + 1),
+            }
+          }
+        }
+      }
+    }
+    return null
+  }
+
+  private extractLine(): { content: string; remaining: string } | null {
+    const newlineIndex = this.buffer.search(/\r?\n/)
+    if (newlineIndex === -1) return null
+
+    return {
+      content: this.buffer.slice(0, newlineIndex).trim(),
+      remaining: this.buffer.slice(newlineIndex + 1),
+    }
+  }
+
+  private tryParseAndUpdate(content: string, remaining: string) {
+    if (!content) {
+      this.buffer = remaining
+      return
+    }
+
+    // Only try to parse JSON-like content
+    if (content.startsWith('{') || content.includes('"jsonrpc"')) {
+      try {
+        const parsed = safeJsonParse(content)
+        this.onMessage(parsed)
+      } catch (error) {
+        this.onError(`Failed to parse JSON: ${error}`, content.slice(0, 200))
+      }
+    }
+    // Non-JSON content is silently ignored
+
+    this.buffer = remaining
+  }
+
+  flush() {
+    if (this.buffer.trim()) {
+      this.tryParseAndUpdate(this.buffer.trim(), '')
+    }
+  }
+}

--- a/src/server/websocket.ts
+++ b/src/server/websocket.ts
@@ -6,6 +6,7 @@ import { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
 import { v4 as uuidv4 } from 'uuid'
 import { WebSocket, WebSocketServer } from 'ws'
 import { Server } from 'http'
+import { safeJsonStringify, safeJsonParse } from '../lib/jsonBuffer.js'
 
 export class WebSocketServerTransport implements Transport {
   private wss!: WebSocketServer
@@ -50,7 +51,7 @@ export class WebSocketServerTransport implements Transport {
 
       ws.on('message', (data: Buffer) => {
         try {
-          const msg = JSON.parse(data.toString())
+          const msg = safeJsonParse(data.toString())
           this.messageHandler?.(msg, clientId)
         } catch (err) {
           this.onerror?.(new Error(`Failed to parse message: ${err}`))
@@ -82,7 +83,7 @@ export class WebSocketServerTransport implements Transport {
       msg.id = parseInt(rawId, 10)
     }
 
-    const payload = JSON.stringify(msg)
+    const payload = safeJsonStringify(msg)
 
     if (cId) {
       // send only to the one client

--- a/tests/jsonBuffer.test.ts
+++ b/tests/jsonBuffer.test.ts
@@ -1,0 +1,223 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  safeJsonStringify,
+  safeJsonParse,
+  JsonBuffer,
+  sanitizeJsonObject,
+} from '../src/lib/jsonBuffer.js'
+
+test('safeJsonStringify should escape Unicode line separator U+2028', () => {
+  const obj = {
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      message: 'Line with \u2028 separator',
+    },
+  }
+
+  const result = safeJsonStringify(obj)
+  assert.ok(result.includes('\\u2028'))
+  assert.ok(!result.includes('\u2028'))
+
+  // Verify it can be parsed back correctly
+  const parsed = JSON.parse(result)
+  assert.strictEqual(parsed.result.message, 'Line with \u2028 separator')
+})
+
+test('safeJsonStringify should escape Unicode paragraph separator U+2029', () => {
+  const obj = {
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      message: 'Line with \u2029 separator',
+    },
+  }
+
+  const result = safeJsonStringify(obj)
+  assert.ok(result.includes('\\u2029'))
+  assert.ok(!result.includes('\u2029'))
+
+  // Verify it can be parsed back correctly
+  const parsed = JSON.parse(result)
+  assert.strictEqual(parsed.result.message, 'Line with \u2029 separator')
+})
+
+test('safeJsonStringify should handle regular JSON without issues', () => {
+  const obj = {
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      message: 'Regular message',
+    },
+  }
+
+  const result = safeJsonStringify(obj)
+  const parsed = JSON.parse(result)
+  assert.deepStrictEqual(parsed, obj)
+})
+
+test('safeJsonStringify should handle both separators in the same string', () => {
+  const obj = {
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      message: 'Text with \u2028 line separator and \u2029 paragraph separator',
+    },
+  }
+
+  const result = safeJsonStringify(obj)
+  assert.ok(result.includes('\\u2028'))
+  assert.ok(result.includes('\\u2029'))
+  assert.ok(!result.includes('\u2028'))
+  assert.ok(!result.includes('\u2029'))
+
+  // Verify it can be parsed back correctly
+  const parsed = JSON.parse(result)
+  assert.strictEqual(
+    parsed.result.message,
+    'Text with \u2028 line separator and \u2029 paragraph separator',
+  )
+})
+
+test('safeJsonParse should handle JSON with raw Unicode line separator U+2028', () => {
+  // Create JSON string with raw Unicode line separator (as would come from problematic source)
+  const problematicJson =
+    '{"jsonrpc":"2.0","id":1,"result":{"message":"Line with \u2028 separator"}}'
+
+  const parsed = safeJsonParse(problematicJson)
+  assert.strictEqual(parsed.result.message, 'Line with \u2028 separator')
+})
+
+test('safeJsonParse should handle JSON with raw Unicode paragraph separator U+2029', () => {
+  // Create JSON string with raw Unicode paragraph separator (as would come from problematic source)
+  const problematicJson =
+    '{"jsonrpc":"2.0","id":1,"result":{"message":"Line with \u2029 separator"}}'
+
+  const parsed = safeJsonParse(problematicJson)
+  assert.strictEqual(parsed.result.message, 'Line with \u2029 separator')
+})
+
+test('safeJsonParse should handle regular JSON without issues', () => {
+  const regularJson =
+    '{"jsonrpc":"2.0","id":1,"result":{"message":"Regular message"}}'
+
+  const parsed = safeJsonParse(regularJson)
+  assert.strictEqual(parsed.result.message, 'Regular message')
+})
+
+test('safeJsonParse should handle JSON with both raw Unicode separators', () => {
+  // Create JSON string with both raw Unicode separators
+  const problematicJson =
+    '{"jsonrpc":"2.0","id":1,"result":{"message":"Text with \u2028 line separator and \u2029 paragraph separator"}}'
+
+  const parsed = safeJsonParse(problematicJson)
+  assert.strictEqual(
+    parsed.result.message,
+    'Text with \u2028 line separator and \u2029 paragraph separator',
+  )
+})
+
+test('JsonBuffer should handle line-based JSON correctly', () => {
+  const messages: any[] = []
+  const errors: string[] = []
+
+  const buffer = new JsonBuffer(
+    (msg) => messages.push(msg),
+    (error) => errors.push(error),
+  )
+
+  buffer.addChunk('{"jsonrpc":"2.0","id":1,"result":"test1"}\n')
+  buffer.addChunk('{"jsonrpc":"2.0","id":2,"result":"test2"}\n')
+
+  assert.strictEqual(messages.length, 2)
+  assert.strictEqual(messages[0].result, 'test1')
+  assert.strictEqual(messages[1].result, 'test2')
+  assert.strictEqual(errors.length, 0)
+})
+
+test('JsonBuffer should handle large JSON without newlines', () => {
+  const messages: any[] = []
+  const errors: string[] = []
+
+  const buffer = new JsonBuffer(
+    (msg) => messages.push(msg),
+    (error) => errors.push(error),
+  )
+
+  const largeContent = 'a'.repeat(2000) // Large content
+  const jsonStr = `{"jsonrpc":"2.0","id":1,"result":{"content":"${largeContent}"}}`
+
+  // Send in chunks without newlines
+  const chunk1 = jsonStr.slice(0, 500)
+  const chunk2 = jsonStr.slice(500, 1000)
+  const chunk3 = jsonStr.slice(1000)
+
+  buffer.addChunk(chunk1)
+  assert.strictEqual(messages.length, 0) // Should not parse incomplete JSON
+
+  buffer.addChunk(chunk2)
+  assert.strictEqual(messages.length, 0) // Still incomplete
+
+  buffer.addChunk(chunk3)
+  assert.strictEqual(messages.length, 1) // Should parse complete JSON
+  assert.strictEqual(messages[0].result.content, largeContent)
+  assert.strictEqual(errors.length, 0)
+})
+
+test('JsonBuffer should ignore non-JSON output (like npm logs)', () => {
+  const messages: any[] = []
+  const errors: string[] = []
+
+  const buffer = new JsonBuffer(
+    (msg) => messages.push(msg),
+    (error) => errors.push(error),
+  )
+
+  // Add non-JSON content that caused the original issue
+  buffer.addChunk('added 41 packages, and audited 42 packages in 2s\n')
+  buffer.addChunk('npm install output line\n')
+  buffer.addChunk('more npm output\n')
+
+  // Add a valid JSON message
+  buffer.addChunk('{"jsonrpc":"2.0","id":1,"result":{"success":true}}\n')
+
+  // Should have parsed only the JSON message, ignoring npm output
+  assert.strictEqual(messages.length, 1)
+  assert.strictEqual(messages[0].jsonrpc, '2.0')
+  assert.strictEqual(messages[0].id, 1)
+
+  // Should not have any errors since non-JSON content was silently ignored
+  assert.strictEqual(errors.length, 0)
+})
+
+test('sanitizeJsonObject should escape Unicode characters for transport', () => {
+  const input = {
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      content: [
+        {
+          type: 'text',
+          text: 'Trust Through Transparency. \u2028\u2028 Open Codebase.',
+        },
+      ],
+    },
+  }
+
+  const sanitized = sanitizeJsonObject(input)
+
+  // Should escape Unicode in nested objects
+  assert.strictEqual(
+    sanitized.result.content[0].text,
+    'Trust Through Transparency. \\u2028\\u2028 Open Codebase.',
+  )
+
+  // Should be safe to stringify with standard JSON.stringify
+  const stringified = JSON.stringify(sanitized)
+  const parsed = JSON.parse(stringified)
+  assert.strictEqual(
+    parsed.result.content[0].text,
+    'Trust Through Transparency. \\u2028\\u2028 Open Codebase.',
+  )
+})


### PR DESCRIPTION
# Problem
Unicode line separators (\u2028, \u2029) in MCP server responses were not being properly escaped, causing display issues on the client side.
# Solution
- Consolidated JSON utilities in src/lib/jsonBuffer.ts with proper Unicode handling
- Added sanitization before sending responses via transport layers
- Improved parsing to handle raw Unicode characters in incoming JSON
# Changes
- New: src/lib/jsonBuffer.ts - unified JSON utilities with Unicode escaping
- Updated: All gateway files to use sanitized JSON before transport
# Testing
- Added comprehensive unit tests for Unicode scenarios
✅ Fixes Unicode display issues
✅ No breaking changes
✅ Improved JSON handling robustness