### PR TITLE
fix: clean up child processes in stateless streamableHttp mode

### DIFF
--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -251,6 +251,12 @@ export async function stdioToStatelessStreamableHttp(
       }
 
       await transport.handleRequest(req, res, req.body)
+
+      // Clean up child process and transport after request completes.
+      // In stateless mode, transport.onclose is never called because there
+      // is no session management, so we must clean up explicitly.
+      child.kill()
+      await transport.close()
     } catch (error) {
       logger.error('Error handling MCP request:', error)
       if (!res.headersSent) {
@@ -263,6 +269,7 @@ export async function stdioToStatelessStreamableHttp(
           id: null,
         })
       }
+      // Child cleanup on error is handled by child.on('exit') and transport.onerror above
     }
   })
 


### PR DESCRIPTION
In stateless mode, each POST request spawns a new child process but transport.onclose is never called because there is no session management. This causes child processes to accumulate indefinitely, leading to OOM.

Add explicit child.kill() and transport.close() after handleRequest() completes, ensuring each request's child process is cleaned up.

- Fixes #108 -- child processes spawned per POST request in stateless mode are never killed because transport.onclose is never called (no session management)
- Adds child.kill() + transport.close() after handleRequest() co