### PR TITLE
Fix SSE reconnection crash: use per-session Server instances

### DIFF
--- a/src/gateways/stdioToSse.ts
+++ b/src/gateways/stdioToSse.ts
@@ -72,14 +72,13 @@ export async function stdioToSse(args: StdioToSseArgs) {
     process.exit(code ?? 1)
   })
 
-  const server = new Server(
-    { name: 'supergateway', version: getVersion() },
-    { capabilities: {} },
-  )
-
   const sessions: Record<
     string,
-    { transport: SSEServerTransport; response: express.Response }
+    {
+      server: Server
+      transport: SSEServerTransport
+      response: express.Response
+    }
   > = {}
 
   const app = express()
@@ -112,11 +111,19 @@ export async function stdioToSse(args: StdioToSseArgs) {
     })
 
     const sseTransport = new SSEServerTransport(`${baseUrl}${messagePath}`, res)
-    await server.connect(sseTransport)
+    const sessionServer = new Server(
+      { name: 'supergateway', version: getVersion() },
+      { capabilities: {} },
+    )
+    await sessionServer.connect(sseTransport)
 
     const sessionId = sseTransport.sessionId
     if (sessionId) {
-      sessions[sessionId] = { transport: sseTransport, response: res }
+      sessions[sessionId] = {
+        server: sessionServer,
+        transport: sseTransport,
+        response: res,
+      }
     }
 
     sseTransport.onmessage = (msg: JSONRPCMessage) => {
@@ -124,19 +131,26 @@ export async function stdioToSse(args: StdioToSseArgs) {
       child.stdin.write(JSON.stringify(msg) + '\n')
     }
 
+    const cleanupSession = () => {
+      if (sessionId && sessions[sessionId]) {
+        sessions[sessionId].server.close().catch(() => {})
+        delete sessions[sessionId]
+      }
+    }
+
     sseTransport.onclose = () => {
       logger.info(`SSE connection closed (session ${sessionId})`)
-      delete sessions[sessionId]
+      cleanupSession()
     }
 
     sseTransport.onerror = (err) => {
       logger.error(`SSE error (session ${sessionId}):`, err)
-      delete sessions[sessionId]
+      cleanupSession()
     }
 
     req.on('close', () => {
       logger.info(`Client disconnected (session ${sessionId})`)
-      delete sessions[sessionId]
+      cleanupSession()
     })
   })
 


### PR DESCRIPTION
## Summary

- Fixes crash when SSE clients reconnect: `"Already connected to a transport. Call close() before connecting to a new transport"`
- Creates a new `Server` instance per SSE session instead of sharing a single instance across all connections
- Adds proper cleanup (`server.close()`) on session disconnect, error, and client close events

## Root Cause

A single `Server` instance was created once and reused for every SSE connection via `server.connect(sseTransport)`. The MCP SDK's `Server.connect()` throws if already connected to a transport. Any second SSE connection (or reconnection after a network blip) would crash the process.

## Fix

- Each SSE connection now gets its own `Server` instance
- Sessions track their `server` alongside `transport` and `response`
- A shared `cleanupSession()` helper ensures `server.close()` is called on disconnect/error/close

## Test plan

- [ ] Verify single SSE client connects and communicates normally
- [ ] Verify multiple concurrent SSE clients each get independent sessions
- [ ] Verify client disconnect + reconnect no longer crashes the process
- [ ] Verify `npm run build` passes cleanly

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>