### PR TITLE
fix(gateways): swallow unhandled promise rejections from async
  transport.send

### DIFF
--- a/src/gateways/stdioToSse.ts
+++ b/src/gateways/stdioToSse.ts
@@ -180,7 +180,10 @@ export async function stdioToSse(args: StdioToSseArgs) {
         logger.info('Child → SSE:', jsonMsg)
         for (const [sid, session] of Object.entries(sessions)) {
           try {
-            session.transport.send(jsonMsg)
+            session.transport.send(jsonMsg).catch((err) => {
+              logger.error(`Failed to send to session ${sid} (async):`, err)
+              delete sessions[sid]
+            })
           } catch (err) {
             logger.error(`Failed to send to session ${sid}:`, err)
             delete sessions[sid]

--- a/src/gateways/stdioToStatefulStreamableHttp.ts
+++ b/src/gateways/stdioToStatefulStreamableHttp.ts
@@ -154,7 +154,9 @@ export async function stdioToStatefulStreamableHttp(
             const jsonMsg = JSON.parse(line)
             logger.info('Child → StreamableHttp:', line)
             try {
-              transport.send(jsonMsg)
+              transport.send(jsonMsg).catch((e) =>
+                logger.error(`Failed to send to StreamableHttp (async)`, e),
+              )
             } catch (e) {
               logger.error(`Failed to send to StreamableHttp`, e)
             }

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -189,7 +189,9 @@ export async function stdioToStatelessStreamableHttp(
             }
 
             try {
-              transport.send(jsonMsg)
+              transport.send(jsonMsg).catch((e) =>
+                logger.error(`Failed to send to StreamableHttp (async)`, e),
+              )
             } catch (e) {
               logger.error(`Failed to send to StreamableHttp`, e)
             }


### PR DESCRIPTION
The stdio->HTTP/SSE gateways wrap transport.send() in a synchronous
try/catch, but transport.send() is async. When the underlying transport
throws (e.g. 'No connection established for request ID: N' because the
client closed the stream between the child emitting a response and the
gateway flushing it), the rejection escapes the sync try/catch and
becomes an uncaughtException, killing the whole Node process.

Seen repeatedly against Claude.ai's remote MCP connector: session
initialize succeeds, tools/list succeeds, then the client cycles its
GET stream and the next child stdout chunk crashes the gateway.

Chain .catch() on the send() promise in all three affected gateways so
the rejection is logged instead of crashing the process. For
stdioToSse, preserve the existing delete-on-failure behavior.
