### PR TITLE
fix: eliminate child-process leak in stdio→streamableHttp (stacks #103 + #111 + #122 + process-group kill)

### DIFF
--- a/src/gateways/stdioToSse.ts
+++ b/src/gateways/stdioToSse.ts
@@ -180,7 +180,10 @@ export async function stdioToSse(args: StdioToSseArgs) {
         logger.info('Child → SSE:', jsonMsg)
         for (const [sid, session] of Object.entries(sessions)) {
           try {
-            session.transport.send(jsonMsg)
+            session.transport.send(jsonMsg).catch((err) => {
+              logger.error(`Failed to send to session ${sid} (async):`, err)
+              delete sessions[sid]
+            })
           } catch (err) {
             logger.error(`Failed to send to session ${sid}:`, err)
             delete sessions[sid]

--- a/src/gateways/stdioToStatefulStreamableHttp.ts
+++ b/src/gateways/stdioToStatefulStreamableHttp.ts
@@ -154,7 +154,9 @@ export async function stdioToStatefulStreamableHttp(
             const jsonMsg = JSON.parse(line)
             logger.info('Child → StreamableHttp:', line)
             try {
-              transport.send(jsonMsg)
+              transport.send(jsonMsg).catch((e) =>
+                logger.error(`Failed to send to StreamableHttp (async)`, e),
+              )
             } catch (e) {
               logger.error(`Failed to send to StreamableHttp`, e)
             }

--- a/src/gateways/stdioToStatefulStreamableHttp.ts
+++ b/src/gateways/stdioToStatefulStreamableHttp.ts
@@ -8,6 +8,7 @@ import { Logger } from '../types.js'
 import { getVersion } from '../lib/getVersion.js'
 import { onSignals } from '../lib/onSignals.js'
 import { serializeCorsOrigin } from '../lib/serializeCorsOrigin.js'
+import { killProcessTree } from '../lib/killProcessTree.js'
 import { randomUUID } from 'node:crypto'
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js'
 import { SessionAccessCounter } from '../lib/sessionAccessCounter.js'
@@ -137,7 +138,11 @@ export async function stdioToStatefulStreamableHttp(
         },
       })
       await server.connect(transport)
-      const child = spawn(stdioCmd, { shell: true })
+      // `detached: true` puts the child in its own process group so we can
+      // signal the whole tree via `process.kill(-pid, ...)`. Without it,
+      // `child.kill()` only signals the `/bin/sh -c` wrapper and leaves the
+      // real MCP server (e.g. npx → node) running.
+      const child = spawn(stdioCmd, { shell: true, detached: true })
       child.on('exit', (code, signal) => {
         logger.error(`Child exited: code=${code}, signal=${signal}`)
         transport.close()
@@ -185,7 +190,7 @@ export async function stdioToStatefulStreamableHttp(
           )
           delete transports[transport.sessionId]
         }
-        child.kill()
+        killProcessTree(child, logger)
       }
 
       transport.onerror = (err) => {
@@ -198,7 +203,7 @@ export async function stdioToStatefulStreamableHttp(
           )
           delete transports[transport.sessionId]
         }
-        child.kill()
+        killProcessTree(child, logger)
       }
     } else {
       // Invalid request

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -11,6 +11,7 @@ import { Logger } from '../types.js'
 import { getVersion } from '../lib/getVersion.js'
 import { onSignals } from '../lib/onSignals.js'
 import { serializeCorsOrigin } from '../lib/serializeCorsOrigin.js'
+import { killProcessTree } from '../lib/killProcessTree.js'
 
 export interface StdioToStreamableHttpArgs {
   stdioCmd: string
@@ -129,11 +130,25 @@ export async function stdioToStatelessStreamableHttp(
 
       await server.connect(transport)
 
-      child = spawn(stdioCmd, { shell: true })
+      // `detached: true` puts the child in its own process group so we can
+      // signal the whole tree via `process.kill(-pid, ...)`. Without it,
+      // `child.kill()` only signals the `/bin/sh -c` wrapper and leaves the
+      // real MCP server (e.g. npx → node) running.
+      child = spawn(stdioCmd, { shell: true, detached: true })
 
       child.on('exit', (code, signal) => {
         logger.error(`Child exited: code=${code}, signal=${signal}`)
         transport.close()
+      })
+
+      // If the HTTP client disconnects mid-request, tear the child down.
+      // transport.onclose is not guaranteed to fire in this path.
+      res.on('close', () => {
+        if (!res.writableEnded) {
+          logger.info('Client disconnected before response completed')
+          killProcessTree(child, logger)
+          transport.close()
+        }
       })
 
       // State tracking for initialization flow
@@ -261,16 +276,12 @@ export async function stdioToStatelessStreamableHttp(
 
       transport.onclose = () => {
         logger.info('StreamableHttp connection closed')
-        if (child && child.exitCode === null && child.signalCode === null) {
-          child.kill()
-        }
+        killProcessTree(child, logger)
       }
 
       transport.onerror = (err) => {
         logger.error(`StreamableHttp error:`, err)
-        if (child && child.exitCode === null && child.signalCode === null) {
-          child.kill()
-        }
+        killProcessTree(child, logger)
       }
 
       await transport.handleRequest(req, res, req.body)
@@ -278,7 +289,7 @@ export async function stdioToStatelessStreamableHttp(
       // Clean up child process and transport after request completes.
       // In stateless mode, transport.onclose is never called because there
       // is no session management, so we must clean up explicitly.
-      child.kill()
+      killProcessTree(child, logger)
       await transport.close()
     } catch (error) {
       logger.error('Error handling MCP request:', error)
@@ -288,7 +299,7 @@ export async function stdioToStatelessStreamableHttp(
           `Killing child [pid: ${child.pid}] due to setup error.`,
           error,
         )
-        child.kill()
+        killProcessTree(child, logger)
       }
 
       if (!res.headersSent) {

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -199,7 +199,9 @@ export async function stdioToStatelessStreamableHttp(
               }
 
               try {
-                transport.send(jsonMsg)
+                transport.send(jsonMsg).catch((e) =>
+                  logger.error(`Failed to send to StreamableHttp (async)`, e),
+                )
               } catch (e) {
                 logger.error(`Failed to send to StreamableHttp`, e)
               }

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -272,6 +272,12 @@ export async function stdioToStatelessStreamableHttp(
       }
 
       await transport.handleRequest(req, res, req.body)
+
+      // Clean up child process and transport after request completes.
+      // In stateless mode, transport.onclose is never called because there
+      // is no session management, so we must clean up explicitly.
+      child.kill()
+      await transport.close()
     } catch (error) {
       logger.error('Error handling MCP request:', error)
 
@@ -293,6 +299,7 @@ export async function stdioToStatelessStreamableHttp(
           id: null,
         })
       }
+      // Child cleanup on error is handled by child.on('exit') and transport.onerror above
     }
   })
 

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import cors, { type CorsOptions } from 'cors'
-import { spawn } from 'child_process'
+import { spawn, type ChildProcess } from 'child_process'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import {
@@ -116,6 +116,8 @@ export async function stdioToStatelessStreamableHttp(
     // to ensure complete isolation. A single instance would cause request ID collisions
     // when multiple clients connect concurrently.
 
+    let child: ChildProcess | null = null
+
     try {
       const server = new Server(
         { name: 'supergateway', version: getVersion() },
@@ -126,7 +128,9 @@ export async function stdioToStatelessStreamableHttp(
       })
 
       await server.connect(transport)
-      const child = spawn(stdioCmd, { shell: true })
+
+      child = spawn(stdioCmd, { shell: true })
+
       child.on('exit', (code, signal) => {
         logger.error(`Child exited: code=${code}, signal=${signal}`)
         transport.close()
@@ -139,69 +143,78 @@ export async function stdioToStatelessStreamableHttp(
       let pendingOriginalMessage: JSONRPCMessage | null = null
 
       let buffer = ''
-      child.stdout.on('data', (chunk: Buffer) => {
-        buffer += chunk.toString('utf8')
-        const lines = buffer.split(/\r?\n/)
-        buffer = lines.pop() ?? ''
-        lines.forEach((line) => {
-          if (!line.trim()) return
-          try {
-            const jsonMsg = JSON.parse(line)
-            logger.info('Child → StreamableHttp:', line)
-
-            // Handle initialize response (both auto and client initiated)
-            if (initializeRequestId && jsonMsg.id === initializeRequestId) {
-              logger.info('Initialize response received')
-              isInitialized = true
-
-              // If this was our auto-initialization, send initialized notification and pending message
-              if (isAutoInitializing) {
-                // Send initialized notification
-                const initializedNotification = createInitializedNotification()
-                logger.info(
-                  `StreamableHttp → Child (initialized): ${JSON.stringify(initializedNotification)}`,
-                )
-                child.stdin.write(
-                  JSON.stringify(initializedNotification) + '\n',
-                )
-
-                // Now send the original message
-                if (pendingOriginalMessage) {
-                  logger.info(
-                    `StreamableHttp → Child (original): ${JSON.stringify(pendingOriginalMessage)}`,
-                  )
-                  child.stdin.write(
-                    JSON.stringify(pendingOriginalMessage) + '\n',
-                  )
-                  pendingOriginalMessage = null
-                }
-
-                // Reset auto-initialize tracking
-                isAutoInitializing = false
-                initializeRequestId = null
-
-                // Don't forward our auto-initialize response to the client
-                return
-              } else {
-                // Client-initiated initialize response, just reset tracking
-                initializeRequestId = null
-              }
-            }
-
+      if (child.stdout) {
+        child.stdout.on('data', (chunk: Buffer) => {
+          buffer += chunk.toString('utf8')
+          const lines = buffer.split(/\r?\n/)
+          buffer = lines.pop() ?? ''
+          lines.forEach((line) => {
+            if (!line.trim()) return
             try {
-              transport.send(jsonMsg)
-            } catch (e) {
-              logger.error(`Failed to send to StreamableHttp`, e)
-            }
-          } catch {
-            logger.error(`Child non-JSON: ${line}`)
-          }
-        })
-      })
+              const jsonMsg = JSON.parse(line)
+              logger.info('Child → StreamableHttp:', line)
 
-      child.stderr.on('data', (chunk: Buffer) => {
-        logger.error(`Child stderr: ${chunk.toString('utf8')}`)
-      })
+              // Handle initialize response (both auto and client initiated)
+              if (initializeRequestId && jsonMsg.id === initializeRequestId) {
+                logger.info('Initialize response received')
+                isInitialized = true
+
+                // If this was our auto-initialization, send initialized notification and pending message
+                if (isAutoInitializing) {
+                  // Send initialized notification
+                  const initializedNotification =
+                    createInitializedNotification()
+                  logger.info(
+                    `StreamableHttp → Child (initialized): ${JSON.stringify(initializedNotification)}`,
+                  )
+                  if (child && child.stdin) {
+                    child.stdin.write(
+                      JSON.stringify(initializedNotification) + '\n',
+                    )
+                  }
+
+                  // Now send the original message
+                  if (pendingOriginalMessage) {
+                    logger.info(
+                      `StreamableHttp → Child (original): ${JSON.stringify(pendingOriginalMessage)}`,
+                    )
+                    if (child && child.stdin) {
+                      child.stdin.write(
+                        JSON.stringify(pendingOriginalMessage) + '\n',
+                      )
+                    }
+                    pendingOriginalMessage = null
+                  }
+
+                  // Reset auto-initialize tracking
+                  isAutoInitializing = false
+                  initializeRequestId = null
+
+                  // Don't forward our auto-initialize response to the client
+                  return
+                } else {
+                  // Client-initiated initialize response, just reset tracking
+                  initializeRequestId = null
+                }
+              }
+
+              try {
+                transport.send(jsonMsg)
+              } catch (e) {
+                logger.error(`Failed to send to StreamableHttp`, e)
+              }
+            } catch {
+              logger.error(`Child non-JSON: ${line}`)
+            }
+          })
+        })
+      }
+
+      if (child.stderr) {
+        child.stderr.on('data', (chunk: Buffer) => {
+          logger.error(`Child stderr: ${chunk.toString('utf8')}`)
+        })
+      }
 
       transport.onmessage = (msg: JSONRPCMessage) => {
         logger.info(`StreamableHttp → Child: ${JSON.stringify(msg)}`)
@@ -223,7 +236,9 @@ export async function stdioToStatelessStreamableHttp(
           logger.info(
             `StreamableHttp → Child (auto-initialize): ${JSON.stringify(initRequest)}`,
           )
-          child.stdin.write(JSON.stringify(initRequest) + '\n')
+          if (child && child.stdin) {
+            child.stdin.write(JSON.stringify(initRequest) + '\n')
+          }
 
           // Don't send the original message yet - it will be sent after initialization
           return
@@ -237,22 +252,37 @@ export async function stdioToStatelessStreamableHttp(
         }
 
         // Send all messages to child process normally
-        child.stdin.write(JSON.stringify(msg) + '\n')
+        if (child && child.stdin) {
+          child.stdin.write(JSON.stringify(msg) + '\n')
+        }
       }
 
       transport.onclose = () => {
         logger.info('StreamableHttp connection closed')
-        child.kill()
+        if (child && child.exitCode === null && child.signalCode === null) {
+          child.kill()
+        }
       }
 
       transport.onerror = (err) => {
         logger.error(`StreamableHttp error:`, err)
-        child.kill()
+        if (child && child.exitCode === null && child.signalCode === null) {
+          child.kill()
+        }
       }
 
       await transport.handleRequest(req, res, req.body)
     } catch (error) {
       logger.error('Error handling MCP request:', error)
+
+      if (child && child.exitCode === null && child.signalCode === null) {
+        logger.error(
+          `Killing child [pid: ${child.pid}] due to setup error.`,
+          error,
+        )
+        child.kill()
+      }
+
       if (!res.headersSent) {
         res.status(500).json({
           jsonrpc: '2.0',

--- a/src/lib/killProcessTree.ts
+++ b/src/lib/killProcessTree.ts
@@ -1,0 +1,57 @@
+import { ChildProcess } from 'child_process'
+import { Logger } from '../types.js'
+
+/**
+ * Kill a spawned child and every process it may have forked.
+ *
+ * Children are spawned with `{ shell: true, detached: true }`, which makes the
+ * direct child a process-group leader. Negative PID in `process.kill` targets
+ * the whole group — so `npx` and its `node` grandchild die together, instead
+ * of only the `/bin/sh -c` wrapper being signalled (which does not forward
+ * signals to its -c command).
+ *
+ * Escalates to SIGKILL after a 5s grace period if anything is still running.
+ */
+export function killProcessTree(
+  child: ChildProcess | null | undefined,
+  logger: Logger,
+): void {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return
+  }
+
+  const pid = child.pid
+  if (pid === undefined) {
+    try {
+      child.kill('SIGTERM')
+    } catch {
+      /* ignore */
+    }
+    return
+  }
+
+  try {
+    process.kill(-pid, 'SIGTERM')
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code
+    if (code !== 'ESRCH') {
+      logger.error(`killProcessTree SIGTERM failed for pgid ${pid}`, err)
+    }
+    return
+  }
+
+  const timer = setTimeout(() => {
+    try {
+      process.kill(-pid, 'SIGKILL')
+      logger.error(`killProcessTree escalated to SIGKILL for pgid ${pid}`)
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code
+      if (code !== 'ESRCH') {
+        logger.error(`killProcessTree SIGKILL failed for pgid ${pid}`, err)
+      }
+    }
+  }, 5000)
+  timer.unref()
+
+  child.once('exit', () => clearTimeout(timer))
+}


### PR DESCRIPTION
## Summary

Rolls up three existing open leak-related PRs plus one fix they all miss. Tested against a 41-day production leak of ~2,676 orphaned Node processes across 10 gateway instances that consumed 55 GB of swap before OOM-killing unrelated services.

## The missing piece

Children are spawned with `{ shell: true }` but **not** `{ detached: true }`. `child.kill()` therefore sends SIGTERM only to the `/bin/sh -c` wrapper. On Linux, a non-interactive sh does not forward signals to its `-c` command, so the real MCP server (typically `npx → node`) survives and is reparented to the still-running gateway. This is why the three existing PRs — all of which add cleanup call sites — still leak in production: every one of them calls the unreliable `child.kill()`.

## Commits

1. **#103** by @move-hoon — kill child if setup throws before `transport.onclose` is registered. Preserved verbatim.
2. **#111** by @quigles1977 — `child.kill() + transport.close()` after `handleRequest()` returns (the stateless happy path, where `transport.onclose` is never fired because there is no session). Preserved verbatim.
3. **#122** by @ecarruthers — `transport.send()` is async; its rejections escape the sync try/catch and crash the whole gateway. Add `.catch()` on all three call sites. Preserved with the stateless hunk re-applied on top of #103's restructure.
4. **New: process-group kill.**
   - `spawn(..., { shell: true, detached: true })` in both streamableHttp handlers so the direct child becomes a process-group leader.
   - New `src/lib/killProcessTree.ts` helper: `process.kill(-pid, 'SIGTERM')`, then escalate to `SIGKILL` after a 5s grace period if the group is still alive. Guards against already-dead children via `exitCode`/`signalCode`, swallows `ESRCH`.
   - Every `child.kill()` call site across the two handlers now routes through `killProcessTree`.
   - Stateless handler additionally wires `res.on('close')` — if the HTTP client disconnects mid-request, `transport.onclose` is not guaranteed to fire, so the child is never signalled at all without this.

## Production evidence (reproducing the leak)

- systemd-managed gateway, one instance per MCP server, long-lived (41 days).
- Stateless mode, `--outputTransport streamableHttp`, remote MCP client (Claude Code) connecting over Tailscale.
- After 41 days: 22,744 tasks in one cgroup, 11.2 GB RSS, monotonically growing `node` count proportional to session count. `pgrep -P <gatewayPid>` confirmed leaked grandchildren parented to the gateway, not orphaned to PID 1 — exactly matching "child.kill() only kills the shell wrapper."

## Scope

- Only the two streamableHttp handlers are touched in the custom commit. `stdioToSse.ts` and `stdioToWs.ts` spawn a single persistent child per gateway instance, not per request, so they have no ongoing leak — the same pattern could be applied to them as a followup for defense-in-depth on shutdown.

## Credits

This PR would not exist without #103 / #111 / #122. Happy to split the new commit into its own PR if the maintainers would prefer to merge the upstream PRs separately first.