### PR TITLE
fix: don't crash on transport.send rejection (closes #84)

### DIFF
--- a/src/gateways/stdioToStatefulStreamableHttp.ts
+++ b/src/gateways/stdioToStatefulStreamableHttp.ts
@@ -153,11 +153,9 @@ export async function stdioToStatefulStreamableHttp(
           try {
             const jsonMsg = JSON.parse(line)
             logger.info('Child → StreamableHttp:', line)
-            try {
-              transport.send(jsonMsg)
-            } catch (e) {
+            transport.send(jsonMsg).catch((e) => {
               logger.error(`Failed to send to StreamableHttp`, e)
-            }
+            })
           } catch {
             logger.error(`Child non-JSON: ${line}`)
           }

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -188,11 +188,9 @@ export async function stdioToStatelessStreamableHttp(
               }
             }
 
-            try {
-              transport.send(jsonMsg)
-            } catch (e) {
+            transport.send(jsonMsg).catch((e) => {
               logger.error(`Failed to send to StreamableHttp`, e)
-            }
+            })
           } catch {
             logger.error(`Child non-JSON: ${line}`)
           }


### PR DESCRIPTION
## Problem

`transport.send(jsonMsg)` is async, but the surrounding `try/catch` in `stdioToStatelessStreamableHttp` and `stdioToStatefulStreamableHttp` is synchronous, so a rejection becomes an unhandled promise rejection and (Node ≥15 default) crashes the gateway process.

The rejection path is easy to trigger: any time an HTTP client aborts a request before the stdio child finishes responding, the SDK tears down the response stream. When the child eventually writes its JSON-RPC response, `transport.send` rejects with `No connection established for request ID: <n>`.

This is the underlying cause of #84 — the `uv run` framing in that report is a red herring. The real common factor is "stdio child slow enough that the SDK client times out and aborts mid-call."

## Repro

Any stdio MCP whose `tools/call` can take longer than the MCP SDK client default `requestTimeoutMsec` (60s). First slow call → client abort → late stdio response → unhandled rejection → process exit. Under launchd / systemd `KeepAlive`, this is a tight crash loop.

Stack trace from a 3.4.3 install (matches #84):

```
Error: No connection established for request ID: 4
    at WebStandardStreamableHTTPServerTransport.send (.../webStandardStreamableHttp.js:720:27)
    at StreamableHTTPServerTransport.send (.../streamableHttp.js:116:43)
    at .../supergateway/dist/gateways/stdioToStatelessStreamableHttp.js:120:39
    at Array.forEach
    at Socket.<anonymous> (.../stdioToStatelessStreamableHttp.js:86:23)
```

## Fix

Catch the rejection. The outer sync `try/catch` is kept because `JSON.parse` upstream is still synchronous.

```diff
-            try {
-              transport.send(jsonMsg)
-            } catch (e) {
+            transport.send(jsonMsg).catch((e) => {
               logger.error(`Failed to send to StreamableHttp`, e)
-            }
+            })
```

Same fix in both gateways. Behavior unchanged in the happy path; closed-stream sends now log instead of crashing.

## Verification

Patched a live install, drove a slow Python stdio MCP via `npx supergateway --stdio ... --outputTransport streamableHttp`, repeatedly aborted requests at the SDK 60s default. Pre-patch: gateway dies on the first slow call. Post-patch: gateway logs `Failed to send to StreamableHttp` and stays up across many cycles.

`npm run build` passes.