### PR TITLE
fix: prevent zombie /bin/sh wrappers leak in stdio transports

### DIFF
--- a/src/gateways/stdioToStatefulStreamableHttp.ts
+++ b/src/gateways/stdioToStatefulStreamableHttp.ts
@@ -137,7 +137,7 @@ export async function stdioToStatefulStreamableHttp(
         },
       })
       await server.connect(transport)
-      const child = spawn(stdioCmd, { shell: true })
+      const child = spawn(stdioCmd, { shell: true, detached: true })
       child.on('exit', (code, signal) => {
         logger.error(`Child exited: code=${code}, signal=${signal}`)
         transport.close()
@@ -183,7 +183,7 @@ export async function stdioToStatefulStreamableHttp(
           )
           delete transports[transport.sessionId]
         }
-        child.kill()
+        try { if (child.pid && !child.killed) process.kill(-child.pid, 'SIGTERM') } catch (e) { try { child.kill() } catch (_) {} }
       }
 
       transport.onerror = (err) => {
@@ -196,7 +196,7 @@ export async function stdioToStatefulStreamableHttp(
           )
           delete transports[transport.sessionId]
         }
-        child.kill()
+        try { if (child.pid && !child.killed) process.kill(-child.pid, 'SIGTERM') } catch (e) { try { child.kill() } catch (_) {} }
       }
     } else {
       // Invalid request

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -126,7 +126,7 @@ export async function stdioToStatelessStreamableHttp(
       })
 
       await server.connect(transport)
-      const child = spawn(stdioCmd, { shell: true })
+      const child = spawn(stdioCmd, { shell: true, detached: true })
       child.on('exit', (code, signal) => {
         logger.error(`Child exited: code=${code}, signal=${signal}`)
         transport.close()
@@ -242,12 +242,12 @@ export async function stdioToStatelessStreamableHttp(
 
       transport.onclose = () => {
         logger.info('StreamableHttp connection closed')
-        child.kill()
+        try { if (child.pid && !child.killed) process.kill(-child.pid, 'SIGTERM') } catch (e) { try { child.kill() } catch (_) {} }
       }
 
       transport.onerror = (err) => {
         logger.error(`StreamableHttp error:`, err)
-        child.kill()
+        try { if (child.pid && !child.killed) process.kill(-child.pid, 'SIGTERM') } catch (e) { try { child.kill() } catch (_) {} }
       }
 
       await transport.handleRequest(req, res, req.body)

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -250,6 +250,18 @@ export async function stdioToStatelessStreamableHttp(
         try { if (child.pid && !child.killed) process.kill(-child.pid, 'SIGTERM') } catch (e) { try { child.kill() } catch (_) {} }
       }
 
+      // In stateless mode the underlying transport never receives a
+      // session-close signal because clients don't issue DELETE.
+      // Close the transport (and group-kill the child) as soon as the
+      // HTTP response finishes — otherwise long-running daemon MCPs
+      // (e.g. lightpanda, headless browsers) stay alive forever and
+      // leak processes per request.
+      const cleanup = () => {
+        try { transport.close() } catch (_) {}
+      }
+      res.on('finish', cleanup)
+      res.on('close', cleanup)
+
       await transport.handleRequest(req, res, req.body)
     } catch (error) {
       logger.error('Error handling MCP request:', error)


### PR DESCRIPTION
## Summary

Calling `child.kill()` on a child spawned with `{ shell: true }` only sends SIGTERM to `/bin/sh`, leaving the actual stdio child (e.g. node MCP server) orphaned and re-parented to init. Over time this leaks hundreds of `/bin/sh` wrappers + their descendants, eventually exhausting the user's process limit and causing `fork() EAGAIN` errors that surface as 502 Bad Gateway / connection timeouts.

## Fix

- Spawn with `detached: true` so the child becomes a process group leader
- On close/error: `process.kill(-child.pid, 'SIGTERM')` to kill the entire process group
- Fallback to bare `child.kill()` for Windows / unusual envs

Applied to both stateful and stateless streamable HTTP transports.

## Reproduction in production

Observed on a Beast box running 5 supergateway-fronted MCPs. After ~24h:
- 544 stale `/bin/sh` wrappers accumulated across 5 MCPs (lightpanda 119, brain-orchestrator 118, qdrant 107, wiremock 101, deepseek 99)
- Total process count for the user reached 2554, hitting `ulimit -u` ceiling
- New MCP requests returning 502 Bad Gateway / EAGAIN
- Restart cleared the leaks: 2554 → 1627 procs (-927)

After this patch + restart, the leak does not recur.

## Test plan

- [ ] CI: existing transport tests still pass
- [ ] Manual: spawn an MCP behind `stdioToStatelessStreamableHttp`, send 100 requests, close transport, observe no orphan `/bin/sh` or node descendants in `ps`
- [ ] Same for `stdioToStatefulStreamableHttp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)