### PR TITLE
docs: add Bilig WorkPaper stdio example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,23 @@ npx -y supergateway \
 
 The Streamable HTTP endpoint defaults to `http://localhost:8000/mcp` (configurable via `--streamableHttpPath`).
 
+### Package-backed stdio server example
+
+Supergateway can also expose an MCP server installed from npm. This example
+bridges Bilig WorkPaper, a local formula workbook MCP server, to Streamable
+HTTP:
+
+```bash
+npx -y supergateway \
+    --stdio "npx -y --package @bilig/workpaper@latest bilig-workpaper-mcp --demo-workpaper-tools" \
+    --outputTransport streamableHttp \
+    --port 8000
+```
+
+The MCP endpoint is available at `http://localhost:8000/mcp`. The Bilig server
+runs over stdio with a no-credential demo WorkPaper; Supergateway handles the
+HTTP transport.
+
 ## stdio → WS
 
 Expose an MCP stdio server as a WebSocket server:


### PR DESCRIPTION
## Summary

Adds a runnable Bilig WorkPaper MCP example for Supergateway.

The example starts `@bilig/workpaper` over stdio, exposes it through Supergateway as Streamable HTTP, and runs a no-key proof that edits `Inputs!B3`, verifies recalculated `Summary!B3`, exports the WorkPaper JSON, and checks restart readback.

## Validation

```bash
npm view @bilig/workpaper version
npm exec --yes --package @bilig/workpaper@latest -- bilig-evaluate --door agent-mcp --json
```

`npm view @bilig/workpaper version` returned `0.154.0`.

The current public Bilig evaluator returned `verified: true` with package versions `@bilig/workpaper@0.154.0` and `xlsx-formula-recalc@0.154.0`. It verified 8 MCP tools, changed `Summary!B3` from `60000` to `96000`, persisted the WorkPaper JSON, restored readback, and confirmed restart readback.

## Notes

The example uses `@bilig/workpaper@latest` in the validation command so the smoke path follows the currently published package. The latest checked package at this refresh is `0.154.0`.

