### PR TITLE
fix: handle async rejection from transport.send() in stdio gateways

### DIFF
--- a/src/gateways/stdioToStatefulStreamableHttp.ts
+++ b/src/gateways/stdioToStatefulStreamableHttp.ts
@@ -153,11 +153,9 @@ export async function stdioToStatefulStreamableHttp(
           try {
             const jsonMsg = JSON.parse(line)
             logger.info('Child → StreamableHttp:', line)
-            try {
-              transport.send(jsonMsg)
-            } catch (e) {
+            transport.send(jsonMsg).catch((e) => {
               logger.error(`Failed to send to StreamableHttp`, e)
-            }
+            })
           } catch {
             logger.error(`Child non-JSON: ${line}`)
           }

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -188,11 +188,9 @@ export async function stdioToStatelessStreamableHttp(
               }
             }
 
-            try {
-              transport.send(jsonMsg)
-            } catch (e) {
+            transport.send(jsonMsg).catch((e) => {
               logger.error(`Failed to send to StreamableHttp`, e)
-            }
+            })
           } catch {
             logger.error(`Child non-JSON: ${line}`)
           }


### PR DESCRIPTION
## Problem

`transport.send()` returns a `Promise<void>`, but both `stdioToStatefulStreamableHttp` and `stdioToStatelessStreamableHttp` wrapped the call in a **synchronous** `try/catch`. This means any rejection from the async operation goes unhandled, which causes Node.js to crash with:

```
Error: No connection established for request ID: <id>
    at WebStandardStreamableHTTPServerTransport.send (webStandardStreamableHttp.js:720)
    at StreamableHTTPServerTransport.send (streamableHttp.js:116)
    at stdioToStatefulStreamableHttp.js:96
```

This crash happens when a client disconnects or times out **before** the child stdio process has finished responding (e.g. during initialization). The sequence is:

1. Client sends `initialize` — HTTP connection is established
2. supergateway spawns child process and forwards the request
3. Client closes the connection (timeout / retry)
4. Child process responds — `transport.send()` rejects because the connection is gone
5. Unhandled rejection → process crashes

## Reproducer

Observed consistently with **Claude Code ≥ 2.1.81** using MCP protocol version `2025-11-25`. Claude Code retries the connection, and on the third attempt the race condition reliably triggers the crash.

## Fix

Replace the synchronous `try/catch` with `.catch()` so the async rejection is handled and the error is **logged instead of crashing the process**:

```ts
// before
try {
  transport.send(jsonMsg)
} catch (e) {
  logger.error(`Failed to send to StreamableHttp`, e)
}

// after
transport.send(jsonMsg).catch((e) => {
  logger.error(`Failed to send to StreamableHttp`, e)
})
```

The same pattern is fixed in both `stdioToStatefulStreamableHttp.ts` and `stdioToStatelessStreamableHttp.ts`.