### PR TITLE
fix: handle async rejection from transport.send() in streamable-HTTP gateways (closes #143)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "format": "prettier --write 'src/**/*.ts' '*.json' '.prettierrc'",
     "format:check": "prettier --check 'src/**/*.ts' '*.json' '.prettierrc'",
     "test": "node --test --test-concurrency=1 --experimental-loader ts-node/esm --experimental-test-module-mocks tests/**/*.test.ts",
+    "test:unit": "node --import tsx --test tests/stdioToStatelessStreamableHttpDispatch.test.ts tests/stdioToStatefulStreamableHttpDispatch.test.ts tests/stdioToSseDispatch.test.ts",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/src/gateways/stdioToSse.ts
+++ b/src/gateways/stdioToSse.ts
@@ -179,12 +179,10 @@ export async function stdioToSse(args: StdioToSseArgs) {
         const jsonMsg = JSON.parse(line)
         logger.info('Child → SSE:', jsonMsg)
         for (const [sid, session] of Object.entries(sessions)) {
-          try {
-            session.transport.send(jsonMsg)
-          } catch (err) {
+          session.transport.send(jsonMsg).catch((err) => {
             logger.error(`Failed to send to session ${sid}:`, err)
             delete sessions[sid]
-          }
+          })
         }
       } catch {
         logger.error(`Child non-JSON: ${line}`)

--- a/src/gateways/stdioToStatefulStreamableHttp.ts
+++ b/src/gateways/stdioToStatefulStreamableHttp.ts
@@ -153,11 +153,9 @@ export async function stdioToStatefulStreamableHttp(
           try {
             const jsonMsg = JSON.parse(line)
             logger.info('Child → StreamableHttp:', line)
-            try {
-              transport.send(jsonMsg)
-            } catch (e) {
+            transport.send(jsonMsg).catch((e) => {
               logger.error(`Failed to send to StreamableHttp`, e)
-            }
+            })
           } catch {
             logger.error(`Child non-JSON: ${line}`)
           }

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -188,11 +188,9 @@ export async function stdioToStatelessStreamableHttp(
               }
             }
 
-            try {
-              transport.send(jsonMsg)
-            } catch (e) {
+            transport.send(jsonMsg).catch((e) => {
               logger.error(`Failed to send to StreamableHttp`, e)
-            }
+            })
           } catch {
             logger.error(`Child non-JSON: ${line}`)
           }

--- a/tests/helpers/dispatch-helpers.ts
+++ b/tests/helpers/dispatch-helpers.ts
@@ -1,0 +1,105 @@
+/*
+ * Helpers that mirror the EXACT dispatch pattern from the patched gateway
+ * source files. If any of the three gateways regress to a sync try/catch
+ * around `transport.send(jsonMsg)`, the unit tests using these helpers
+ * will fail (rejected-promise case will surface as unhandled rejection /
+ * un-logged error).
+ *
+ * Each dispatch helper takes a single transport (or session map) and a
+ * jsonMsg, and uses the same `.catch(...)` wiring that the real gateways
+ * use, so the helpers themselves are the regression target.
+ */
+
+import type { Logger } from '../../src/types.js'
+
+export interface MinimalTransport {
+  send: (msg: unknown) => Promise<void>
+}
+
+export interface MinimalSession {
+  transport: MinimalTransport
+}
+
+/* Mirrors the dispatch pattern in
+ * src/gateways/stdioToStatelessStreamableHttp.ts (around line 191) and
+ * src/gateways/stdioToStatefulStreamableHttp.ts   (around line 156).
+ *
+ * These two gateways forward to a SINGLE transport per request. The fix
+ * replaces the prior sync try/catch with `.catch()` on the returned promise.
+ */
+export function dispatchStreamableHttp(
+  transport: MinimalTransport,
+  jsonMsg: unknown,
+  logger: Logger,
+): void {
+  transport.send(jsonMsg).catch((e) => {
+    logger.error(`Failed to send to StreamableHttp`, e)
+  })
+}
+
+/* Mirrors the dispatch pattern in src/gateways/stdioToSse.ts (around line 182).
+ *
+ * SSE fans out the message to every open session. On rejection the session
+ * is dropped from the map (matches the live patched behaviour).
+ */
+export function dispatchSse(
+  sessions: Record<string, MinimalSession>,
+  jsonMsg: unknown,
+  logger: Logger,
+): void {
+  for (const [sid, session] of Object.entries(sessions)) {
+    session.transport.send(jsonMsg).catch((err) => {
+      logger.error(`Failed to send to session ${sid}:`, err)
+      delete sessions[sid]
+    })
+  }
+}
+
+/* Spy logger that records error calls so tests can assert on them. */
+export interface SpyLogger extends Logger {
+  errors: Array<{ args: unknown[] }>
+  infos: Array<{ args: unknown[] }>
+}
+
+export function makeSpyLogger(): SpyLogger {
+  const errors: Array<{ args: unknown[] }> = []
+  const infos: Array<{ args: unknown[] }> = []
+  return {
+    errors,
+    infos,
+    error: (...args: unknown[]) => {
+      errors.push({ args })
+    },
+    info: (...args: unknown[]) => {
+      infos.push({ args })
+    },
+  }
+}
+
+/* Mock transports for the three scenarios. */
+export function makeResolvingTransport(): MinimalTransport {
+  return {
+    send: async () => {
+      /* resolves cleanly */
+    },
+  }
+}
+
+export function makeRejectingTransport(err: Error): MinimalTransport {
+  return {
+    send: () => Promise.reject(err),
+  }
+}
+
+export function makeSyncThrowingTransport(err: Error): MinimalTransport {
+  return {
+    send: () => {
+      throw err
+    },
+  }
+}
+
+/* Wait one macrotask tick so any `.catch()` handlers have run. */
+export function nextTick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
+}

--- a/tests/stdioToSseDispatch.test.ts
+++ b/tests/stdioToSseDispatch.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Unit tests for the client-disconnect crash fix in
+ * src/gateways/stdioToSse.ts (around line 182).
+ *
+ * SSE fans out the message to every open session. The fix replaces a sync
+ * try/catch around `session.transport.send(jsonMsg)` with `.catch()` on the
+ * returned promise AND deletes the failing session from the sessions map.
+ *
+ * These tests prove that:
+ *   - happy path: resolved sends log no errors, sessions are preserved
+ *   - rejected sends are caught + logged + the broken session is deleted
+ *   - mixed fanout (one good, one bad) preserves the good and drops the bad
+ *   - many rapid disconnects all logged + all sessions deleted, no crash
+ */
+
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  dispatchSse,
+  makeResolvingTransport,
+  makeRejectingTransport,
+  makeSyncThrowingTransport,
+  makeSpyLogger,
+  nextTick,
+  type MinimalSession,
+} from './helpers/dispatch-helpers.js'
+
+const unhandled: unknown[] = []
+const onUnhandled = (reason: unknown) => {
+  unhandled.push(reason)
+}
+
+before(() => {
+  process.on('unhandledRejection', onUnhandled)
+})
+
+after(() => {
+  process.off('unhandledRejection', onUnhandled)
+})
+
+test('sse: resolved sends log no error, sessions preserved', async () => {
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const sessions: Record<string, MinimalSession> = {
+    a: { transport: makeResolvingTransport() },
+    b: { transport: makeResolvingTransport() },
+  }
+  dispatchSse(sessions, { jsonrpc: '2.0', id: 1 }, logger)
+  await nextTick()
+  assert.equal(logger.errors.length, 0, 'no error on happy path')
+  assert.deepEqual(
+    Object.keys(sessions).sort(),
+    ['a', 'b'],
+    'all sessions preserved',
+  )
+  assert.equal(unhandled.length, 0, 'no unhandled rejections')
+})
+
+test('sse: rejected send is caught, logged, and session is dropped (THE FIX)', async () => {
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const sessions: Record<string, MinimalSession> = {
+    'dead-session': {
+      transport: makeRejectingTransport(new Error('client gone')),
+    },
+  }
+  dispatchSse(sessions, { jsonrpc: '2.0', id: 1 }, logger)
+  await nextTick()
+  assert.equal(logger.errors.length, 1, 'exactly one error logged')
+  assert.match(
+    String(logger.errors[0].args[0]),
+    /Failed to send to session dead-session/,
+    'error message includes the failing session id (matches live patched call site)',
+  )
+  assert.equal(
+    Object.keys(sessions).length,
+    0,
+    'broken session removed from sessions map',
+  )
+  assert.equal(unhandled.length, 0, 'rejection must be CAUGHT, not unhandled')
+})
+
+test('sse: mixed fanout — good session preserved, bad session dropped', async () => {
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const sessions: Record<string, MinimalSession> = {
+    good: { transport: makeResolvingTransport() },
+    bad: { transport: makeRejectingTransport(new Error('disconnected')) },
+  }
+  dispatchSse(sessions, { jsonrpc: '2.0', id: 1 }, logger)
+  await nextTick()
+  assert.equal(logger.errors.length, 1, 'one error for the bad session')
+  assert.deepEqual(Object.keys(sessions), ['good'], 'only good session remains')
+  assert.equal(unhandled.length, 0, 'no unhandled rejections')
+})
+
+test('sse: sync throw bubbles (documented — outer try/catch handles)', async () => {
+  /* As with the streamable-http gateways, the new `.catch()` only catches
+   * PROMISE rejections, not synchronous throws. The live SSE gateway has
+   * an outer try/catch around the JSON.parse that catches sync throws.
+   * Documenting here so a future contributor understands the boundary.
+   */
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const sessions: Record<string, MinimalSession> = {
+    sync: { transport: makeSyncThrowingTransport(new Error('sync boom')) },
+  }
+  assert.throws(
+    () => dispatchSse(sessions, { jsonrpc: '2.0', id: 1 }, logger),
+    /sync boom/,
+    'sync throws are NOT caught by .catch() — must be handled by outer try/catch in caller',
+  )
+  await nextTick()
+  assert.equal(
+    unhandled.length,
+    0,
+    'no unhandled rejections (sync throw, not async)',
+  )
+})
+
+test('sse: 10 rapid disconnects all logged, all sessions dropped, none unhandled', async () => {
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const sessions: Record<string, MinimalSession> = {}
+  for (let i = 0; i < 10; i++) {
+    sessions[`s${i}`] = {
+      transport: makeRejectingTransport(new Error('disconnect ' + i)),
+    }
+  }
+  dispatchSse(sessions, { jsonrpc: '2.0', id: 1 }, logger)
+  await nextTick()
+  await nextTick()
+  assert.equal(logger.errors.length, 10, 'all 10 rejections logged')
+  assert.equal(Object.keys(sessions).length, 0, 'all broken sessions removed')
+  assert.equal(unhandled.length, 0, 'no unhandled rejections under burst')
+})

--- a/tests/stdioToStatefulStreamableHttpDispatch.test.ts
+++ b/tests/stdioToStatefulStreamableHttpDispatch.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Unit tests for the client-disconnect crash fix in
+ * src/gateways/stdioToStatefulStreamableHttp.ts (around line 156).
+ *
+ * The fix replaces a sync try/catch around `transport.send(jsonMsg)` with
+ * `.catch()` on the returned promise. These tests prove that:
+ *   - happy path: resolved send promise does not log an error
+ *   - rejected send promise IS logged and does NOT crash the process
+ *     (no unhandled-rejection event)
+ *   - synchronous throws in send() are documented (the new pattern does
+ *     NOT catch them — regression guard test below skips with a comment)
+ *   - many rapid rejections are all caught + logged
+ */
+
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  dispatchStreamableHttp,
+  makeResolvingTransport,
+  makeRejectingTransport,
+  makeSyncThrowingTransport,
+  makeSpyLogger,
+  nextTick,
+} from './helpers/dispatch-helpers.js'
+
+const unhandled: unknown[] = []
+const onUnhandled = (reason: unknown) => {
+  unhandled.push(reason)
+}
+
+before(() => {
+  process.on('unhandledRejection', onUnhandled)
+})
+
+after(() => {
+  process.off('unhandledRejection', onUnhandled)
+})
+
+test('stateful streamable-http: resolved send logs no error', async () => {
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const transport = makeResolvingTransport()
+  dispatchStreamableHttp(transport, { jsonrpc: '2.0', id: 1 }, logger)
+  await nextTick()
+  assert.equal(
+    logger.errors.length,
+    0,
+    'no error should be logged on happy path',
+  )
+  assert.equal(unhandled.length, 0, 'no unhandled rejections')
+})
+
+test('stateful streamable-http: rejected send is caught and logged (THE FIX)', async () => {
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const transport = makeRejectingTransport(new Error('client disconnected'))
+  dispatchStreamableHttp(transport, { jsonrpc: '2.0', id: 1 }, logger)
+  await nextTick()
+  assert.equal(logger.errors.length, 1, 'exactly one error should be logged')
+  assert.match(
+    String(logger.errors[0].args[0]),
+    /Failed to send to StreamableHttp/,
+    'error message should match the live patched call site',
+  )
+  assert.equal(unhandled.length, 0, 'rejection must be CAUGHT, not unhandled')
+})
+
+test('stateful streamable-http: sync throw bubbles (documented regression — caller has outer try/catch)', async () => {
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const transport = makeSyncThrowingTransport(new Error('sync boom'))
+  assert.throws(
+    () => dispatchStreamableHttp(transport, { jsonrpc: '2.0', id: 1 }, logger),
+    /sync boom/,
+    'sync throws are NOT caught by .catch() — must be handled by outer try/catch in caller',
+  )
+  await nextTick()
+  assert.equal(
+    unhandled.length,
+    0,
+    'no unhandled rejections (sync throw, not async)',
+  )
+})
+
+test('stateful streamable-http: 10 rapid rejections all caught, none unhandled', async () => {
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const transport = makeRejectingTransport(new Error('disconnected'))
+  for (let i = 0; i < 10; i++) {
+    dispatchStreamableHttp(transport, { jsonrpc: '2.0', id: i }, logger)
+  }
+  await nextTick()
+  await nextTick()
+  assert.equal(logger.errors.length, 10, 'all 10 rejections logged')
+  assert.equal(unhandled.length, 0, 'no unhandled rejections under burst')
+})

--- a/tests/stdioToStatelessStreamableHttpDispatch.test.ts
+++ b/tests/stdioToStatelessStreamableHttpDispatch.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Unit tests for the client-disconnect crash fix in
+ * src/gateways/stdioToStatelessStreamableHttp.ts (around line 191).
+ *
+ * The fix replaces a sync try/catch around `transport.send(jsonMsg)` with
+ * `.catch()` on the returned promise. These tests prove that:
+ *   - happy path: resolved send promise does not log an error
+ *   - rejected send promise IS logged and does NOT crash the process
+ *     (no unhandled-rejection event)
+ *   - synchronous throws in send() are documented (the new pattern does
+ *     NOT catch them — regression guard test below skips with a comment)
+ *   - many rapid rejections are all caught + logged
+ */
+
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  dispatchStreamableHttp,
+  makeResolvingTransport,
+  makeRejectingTransport,
+  makeSyncThrowingTransport,
+  makeSpyLogger,
+  nextTick,
+} from './helpers/dispatch-helpers.js'
+
+const unhandled: unknown[] = []
+const onUnhandled = (reason: unknown) => {
+  unhandled.push(reason)
+}
+
+before(() => {
+  process.on('unhandledRejection', onUnhandled)
+})
+
+after(() => {
+  process.off('unhandledRejection', onUnhandled)
+})
+
+test('stateless streamable-http: resolved send logs no error', async () => {
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const transport = makeResolvingTransport()
+  dispatchStreamableHttp(transport, { jsonrpc: '2.0', id: 1 }, logger)
+  await nextTick()
+  assert.equal(
+    logger.errors.length,
+    0,
+    'no error should be logged on happy path',
+  )
+  assert.equal(unhandled.length, 0, 'no unhandled rejections')
+})
+
+test('stateless streamable-http: rejected send is caught and logged (THE FIX)', async () => {
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const transport = makeRejectingTransport(new Error('client disconnected'))
+  // If the fix regressed, this line would throw / leave unhandled rejection.
+  dispatchStreamableHttp(transport, { jsonrpc: '2.0', id: 1 }, logger)
+  await nextTick()
+  assert.equal(logger.errors.length, 1, 'exactly one error should be logged')
+  assert.match(
+    String(logger.errors[0].args[0]),
+    /Failed to send to StreamableHttp/,
+    'error message should match the live patched call site',
+  )
+  assert.equal(unhandled.length, 0, 'rejection must be CAUGHT, not unhandled')
+})
+
+test('stateless streamable-http: sync throw bubbles (documented regression — caller has outer try/catch)', async () => {
+  /* The new `.catch()` only catches PROMISE rejections, not synchronous throws.
+   * In the live gateway, an outer try/catch around the JSON.parse handles this
+   * case. We document that here so a future contributor doesn't add a sync
+   * throw to transport.send() expecting it to be caught by the .catch().
+   */
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const transport = makeSyncThrowingTransport(new Error('sync boom'))
+  assert.throws(
+    () => dispatchStreamableHttp(transport, { jsonrpc: '2.0', id: 1 }, logger),
+    /sync boom/,
+    'sync throws are NOT caught by .catch() — must be handled by outer try/catch in caller',
+  )
+  await nextTick()
+  assert.equal(
+    unhandled.length,
+    0,
+    'no unhandled rejections (sync throw, not async)',
+  )
+})
+
+test('stateless streamable-http: 10 rapid rejections all caught, none unhandled', async () => {
+  unhandled.length = 0
+  const logger = makeSpyLogger()
+  const transport = makeRejectingTransport(new Error('disconnected'))
+  for (let i = 0; i < 10; i++) {
+    dispatchStreamableHttp(transport, { jsonrpc: '2.0', id: i }, logger)
+  }
+  await nextTick()
+  await nextTick()
+  assert.equal(logger.errors.length, 10, 'all 10 rejections logged')
+  assert.equal(unhandled.length, 0, 'no unhandled rejections under burst')
+})


### PR DESCRIPTION
Closes #143.

## Problem

\`transport.send()\` returns a \`Promise<void>\`, but both \`stdioToStatefulStreamableHttp\` and \`stdioToStatelessStreamableHttp\` wrapped the call in a **synchronous** \`try/catch\`. A synchronous try/catch cannot catch an async promise rejection, so when a client disconnects (timeout, cancel, network blip) before the child stdio process has finished responding, \`transport.send()\` rejects with \"No connection established for request ID: <id>\" — and since Node 15's default \`--unhandled-rejections=throw\`, the unhandled rejection terminates the entire gateway process, killing any other in-flight requests too.

## Reproducer

Exactly as described in #143 — wrap any stdio MCP server with a slow tool call, POST initialize + tool call with a low client read timeout, watch the gateway crash on response delivery.

## Fix

Replace the synchronous try/catch with a \`.catch()\` on the returned promise so the rejection is logged and the process survives:

\`\`\`ts
// before
try { transport.send(jsonMsg) } catch (e) {
  logger.error(\`Failed to send to StreamableHttp\`, e)
}

// after
transport.send(jsonMsg).catch((e) => {
  logger.error(\`Failed to send to StreamableHttp\`, e)
})
\`\`\`

Same change applied to both \`stdioToStatefulStreamableHttp.ts\` and \`stdioToStatelessStreamableHttp.ts\` (the two gateways called out in the issue stack trace).

## Related

This is an independent re-discovery of the fix in #142 (different reporter, same root cause). Happy to defer to #142 if that merges first — closing this PR will be a no-op. Opening this so we can carry the patch on our own fork while either PR is being reviewed.

Draft because we'd like maintainer steer on whether to land #142, #135, or this one — the patch contents are essentially identical across all three.