### PR TITLE
Fix CLI version output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { streamableHttpToStdio } from './gateways/streamableHttpToStdio.js'
 import { headers } from './lib/headers.js'
 import { corsOrigin } from './lib/corsOrigin.js'
 import { getLogger } from './lib/getLogger.js'
+import { getVersion } from './lib/getVersion.js'
 import { stdioToStatelessStreamableHttp } from './gateways/stdioToStatelessStreamableHttp.js'
 import { stdioToStatefulStreamableHttp } from './gateways/stdioToStatefulStreamableHttp.js'
 
@@ -129,6 +130,7 @@ async function main() {
         'MCP protocol version to use for auto-initialization. Defaults to "2024-11-05" if not specified.',
       default: '2024-11-05',
     })
+    .version(getVersion())
     .help()
     .parseSync()
 

--- a/tests/cliVersion.test.ts
+++ b/tests/cliVersion.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const rootDir = process.cwd()
+const packageJson = JSON.parse(
+  readFileSync(join(rootDir, 'package.json'), 'utf-8'),
+) as { version: string }
+
+test('--version prints the package version', () => {
+  const tsxBin = join(
+    rootDir,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+  )
+  const result = spawnSync(tsxBin, ['src/index.ts', '--version'], {
+    cwd: rootDir,
+    encoding: 'utf-8',
+  })
+
+  assert.strictEqual(result.status, 0)
+  assert.strictEqual(result.stdout.trim(), packageJson.version)
+  assert.doesNotMatch(result.stderr, /You must specify one of/)
+})


### PR DESCRIPTION
## What changed

- Pass the existing `getVersion()` value into yargs via `.version(getVersion())`.
- Add a CLI smoke test that verifies `--version` prints the package version and does not fall through to the missing-transport validation path.

## Why

The published CLI currently prints `unknown` for `supergateway --version` under `npx --package=supergateway@3.4.3`, even though `package.json` contains `3.4.3`. yargs' default version guessing can be affected by npm exec wrapper package metadata, so the CLI should provide the package version explicitly.

## Validation

- `npm run build`
- `npx tsc --noEmit --pretty false`
- `TS_NODE_LOG_ERROR=true npm test` (9/9 passing; existing tests emit TypeScript diagnostics under local Node v25 before continuing)
- `npm run format:check`
- `node dist/index.js --version`
- `node dist/index.js --help`
- `npm exec --yes --package=<local tarball> -- supergateway --version`
- `git diff --check`
