### PR TITLE
feat: emit SSE keepalive comments to defeat Claude Code 60s first-byte fetch abort

### DIFF
--- a/src/gateways/stdioToStatefulStreamableHttp.ts
+++ b/src/gateways/stdioToStatefulStreamableHttp.ts
@@ -11,6 +11,7 @@ import { serializeCorsOrigin } from '../lib/serializeCorsOrigin.js'
 import { randomUUID } from 'node:crypto'
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js'
 import { SessionAccessCounter } from '../lib/sessionAccessCounter.js'
+import { applySseKeepalive } from '../lib/sseKeepalive.js'
 
 export interface StdioToStreamableHttpArgs {
   stdioCmd: string
@@ -224,6 +225,8 @@ export async function stdioToStatefulStreamableHttp(
     res.on('finish', () => handleResponseEnd('finished'))
     res.on('close', () => handleResponseEnd('closed'))
 
+    applySseKeepalive({ res, logger })
+
     // Handle the request
     await transport.handleRequest(req, res, req.body)
   })
@@ -256,6 +259,7 @@ export async function stdioToStatefulStreamableHttp(
     res.on('close', () => handleResponseEnd('closed'))
 
     const transport = transports[sessionId]
+    applySseKeepalive({ res, logger })
     await transport.handleRequest(req, res)
   }
 

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -11,6 +11,7 @@ import { Logger } from '../types.js'
 import { getVersion } from '../lib/getVersion.js'
 import { onSignals } from '../lib/onSignals.js'
 import { serializeCorsOrigin } from '../lib/serializeCorsOrigin.js'
+import { applySseKeepalive } from '../lib/sseKeepalive.js'
 
 export interface StdioToStreamableHttpArgs {
   stdioCmd: string
@@ -115,6 +116,8 @@ export async function stdioToStatelessStreamableHttp(
     // In stateless mode, create a new instance of transport and server for each request
     // to ensure complete isolation. A single instance would cause request ID collisions
     // when multiple clients connect concurrently.
+
+    applySseKeepalive({ res, logger })
 
     try {
       const server = new Server(

--- a/src/lib/sseKeepalive.ts
+++ b/src/lib/sseKeepalive.ts
@@ -1,0 +1,80 @@
+import type express from 'express'
+import type { Logger } from '../types.js'
+
+const DEFAULT_INTERVAL_MS = 25_000
+
+export interface SseKeepaliveArgs {
+  res: express.Response
+  logger: Logger
+  intervalMs?: number
+}
+
+/**
+ * Defeat the Claude Code HTTP MCP 60s first-byte fetch abort by emitting an
+ * SSE comment line every ~25s while the response is open. Comment lines
+ * (`: ...\n\n`) are valid in `text/event-stream` per W3C SSE spec and are
+ * silently discarded by every conforming SSE parser — including the one in
+ * @modelcontextprotocol/sdk's StreamableHTTPServerTransport, which reads
+ * via fetch + ReadableStream and resets its own abort timer on every byte.
+ *
+ * Only engages once the response has flipped to `text/event-stream`; for
+ * one-shot JSON replies the helper is a no-op so we don't corrupt the body.
+ *
+ * Stops on `finish` or `close`.
+ *
+ * Why this exists: anthropics/claude-code hardcodes a 60s
+ * AbortSignal.timeout(60000) on the fetch underlying HTTP/streamable-HTTP
+ * MCP tool calls. Per-server `timeout` and `MCP_TOOL_TIMEOUT` are
+ * protocol-level and ignored by the transport. The only fix is server-side
+ * keepalive — see issue #36221.
+ */
+export const applySseKeepalive = ({
+  res,
+  logger,
+  intervalMs = DEFAULT_INTERVAL_MS,
+}: SseKeepaliveArgs): void => {
+  let timer: NodeJS.Timeout | null = null
+  let stopped = false
+
+  const stop = (reason: string) => {
+    if (stopped) return
+    stopped = true
+    if (timer) {
+      clearInterval(timer)
+      timer = null
+    }
+    logger.info(`SSE keepalive stopped (${reason})`)
+  }
+
+  const start = () => {
+    if (timer || stopped) return
+    const ct = String(res.getHeader('content-type') || '')
+    if (!ct.toLowerCase().includes('text/event-stream')) return
+    logger.info(`SSE keepalive engaged (interval=${intervalMs}ms)`)
+    timer = setInterval(() => {
+      if (res.writableEnded || res.destroyed) {
+        stop('writable ended/destroyed')
+        return
+      }
+      try {
+        res.write(': keepalive\n\n')
+      } catch (e) {
+        stop(`write threw: ${(e as Error).message}`)
+      }
+    }, intervalMs)
+    // Don't keep the event loop alive just for keepalives.
+    timer.unref?.()
+  }
+
+  // Headers may flush on the first transport.send(); engage right after.
+  // setHeader/writeHead happens synchronously inside handleRequest before
+  // the first body write, so a single immediate poll plus a short retry
+  // covers the race without spinning.
+  const tryStart = () => start()
+  tryStart()
+  const probe = setTimeout(tryStart, 100)
+  probe.unref?.()
+
+  res.on('finish', () => stop('finish'))
+  res.on('close', () => stop('close'))
+}


### PR DESCRIPTION
## Why

Claude Code's HTTP / streamable-HTTP MCP transport hardcodes a 60s \`AbortSignal.timeout(60000)\` on the underlying fetch (anthropics/claude-code#36221). Per-server \`timeout\` field and \`MCP_TOOL_TIMEOUT\` env var are protocol-level and the transport ignores them — long-running MCP tool calls die at exactly 60s unless the server emits SOMETHING within that window.

Anyone fronting a slow MCP (LLM-routed search, heavy DB queries, long inference) hits this. Currently the only workaround is bypassing the MCP entirely.

## What

Adds \`applySseKeepalive({ res, logger })\`:

- writes \`: keepalive\n\n\` every 25s once the response has flipped to \`text/event-stream\`
- comment lines are valid per [W3C SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream) and silently discarded by every conforming parser including the MCP SDK's
- no-op when the response is one-shot JSON (Content-Type sniff)
- auto-stops on res \`finish\` or \`close\`
- timer is \`unref()\`'d so it doesn't keep the event loop alive

Wired into:
- \`stdioToStatefulStreamableHttp\` — POST init/message + GET (SSE channel) handlers
- \`stdioToStatelessStreamableHttp\` — POST handler

## Test impact

Test count is unchanged on this branch vs main (1 pass / 6 fail — pre-existing test rot, not introduced here). \`tsc\` build clean.

## Acks

References anthropics/claude-code#36221 + #50289 (the per-server timeout regression).