### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "supergateway",
   "version": "3.4.3",
   "description": "Run MCP stdio servers over SSE, Streamable HTTP or visa versa",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/supercorp-ai/supergateway.git"


### PR DESCRIPTION
## Summary

- add MIT license metadata to the package manifest
- align npm metadata with the repository license

## Verification

- `npm view supergateway@latest name version license repository homepage bugs --json`
- `node -e "const p=require('./package.json'); if (p.license !== 'MIT') throw new Error('license mismatch'); console.log(p.name, p.version, p.license)"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`
