### PR TITLE
fix(stateless): reap spawned child on HTTP disconnect to prevent process leak

### DIFF
--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -127,10 +127,26 @@ export async function stdioToStatelessStreamableHttp(
 
       await server.connect(transport)
       const child = spawn(stdioCmd, { shell: true })
+
+      // Single idempotent cleanup — called from transport.onclose, transport.onerror,
+      // AND res.on('close') so the spawned child is always reaped regardless of
+      // whether the HTTP connection closes cleanly or drops unexpectedly.
+      let cleaned = false
+      const cleanup = () => {
+        if (cleaned) return
+        cleaned = true
+        child.kill()
+        transport.close()
+      }
+
       child.on('exit', (code, signal) => {
         logger.error(`Child exited: code=${code}, signal=${signal}`)
         transport.close()
       })
+
+      // Reap child + transport whenever the HTTP response closes — this covers
+      // unclean client disconnects where transport.onclose would otherwise never fire.
+      res.on('close', cleanup)
 
       // State tracking for initialization flow
       let isInitialized = false
@@ -242,12 +258,12 @@ export async function stdioToStatelessStreamableHttp(
 
       transport.onclose = () => {
         logger.info('StreamableHttp connection closed')
-        child.kill()
+        cleanup()
       }
 
       transport.onerror = (err) => {
         logger.error(`StreamableHttp error:`, err)
-        child.kill()
+        cleanup()
       }
 
       await transport.handleRequest(req, res, req.body)


### PR DESCRIPTION
## Problem

In stateless mode (`--outputTransport streamableHttp` without `--stateful`), each `POST /mcp` in `stdioToStatelessStreamableHttp` spawns a fresh child process:

```ts
const child = spawn(stdioCmd, { shell: true })
```

Cleanup was wired only through two event paths:
- `transport.onclose → child.kill()`
- `child.on('exit') → transport.close()`

**Neither fires on unclean HTTP disconnect.** When a client drops the connection (network timeout, proxy close, or clients like [Hermes](https://github.com/NousResearch/hermes-agent) that reconnect per tool call without an HTTP DELETE), the spawned child and its `StreamableHTTPServerTransport` + `Server` objects are never reaped. Under sustained traffic this accumulates unboundedly.

**Observed in production:** `mcp-server-gsc` and `ga4-mcp` containers grew to **4.4 GB** and **2.6 GB** respectively over 23 hours of agent traffic, eventually taking down the host. Each leaked child is a full standalone Node server (tens of MB each).

## Fix

Two changes, both in the `POST` handler:

1. **Introduce an idempotent `cleanup()` closure** (guarded by a `cleaned` flag) that calls both `child.kill()` and `transport.close()`. Safe to call multiple times from concurrent event paths.

2. **Bind `cleanup` to `res.on('close')`** — this fires on every HTTP response end, clean or unclean, so the spawned child is always reaped when the request lifecycle ends regardless of how the connection was terminated.

`transport.onclose` and `transport.onerror` are updated to call `cleanup()` instead of calling `child.kill()` directly, so all three paths share the same idempotent teardown.

```ts
let cleaned = false
const cleanup = () => {
  if (cleaned) return
  cleaned = true
  child.kill()
  transport.close()
}

// Always fires — covers clean close, error, AND unclean disconnect
res.on('close', cleanup)

transport.onclose = () => {
  logger.info('StreamableHttp connection closed')
  cleanup()
}

transport.onerror = (err) => {
  logger.error(`StreamableHttp error:`, err)
  cleanup()
}
```

`child.on('exit')` is left as-is calling `transport.close()` directly (child dying first → close transport), which is safe since `transport.close()` is idempotent.

## Testing

The leak can be reproduced by running supergateway in stateless mode and repeatedly dropping HTTP connections mid-request (e.g. `curl --max-time 0.1`), then observing `ps aux` for accumulating child processes. With this fix, each disconnected request leaves no orphaned children.