### PR TITLE
Return 404 for unknown stateful sessions

### DIFF
--- a/src/gateways/stdioToStatefulStreamableHttp.ts
+++ b/src/gateways/stdioToStatefulStreamableHttp.ts
@@ -198,6 +198,16 @@ export async function stdioToStatefulStreamableHttp(
         }
         child.kill()
       }
+    } else if (sessionId) {
+      res.status(404).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32001,
+          message: 'Session not found',
+        },
+        id: null,
+      })
+      return
     } else {
       // Invalid request
       res.status(400).json({

--- a/tests/stdioToStatefulStreamableHttp.test.ts
+++ b/tests/stdioToStatefulStreamableHttp.test.ts
@@ -68,3 +68,46 @@ test('stdioToStatefulStreamableHttp listTools and callTool', async () => {
   await client.close()
   transport.close()
 })
+
+test('stdioToStatefulStreamableHttp returns 404 for unknown session IDs', async () => {
+  await new Promise((r) => setTimeout(r, 2000))
+
+  const unknownSession = await fetch(MCP_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      'mcp-session-id': 'unknown-session-id',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+    }),
+  })
+
+  assert.strictEqual(unknownSession.status, 404)
+  assert.deepStrictEqual(await unknownSession.json(), {
+    jsonrpc: '2.0',
+    error: {
+      code: -32001,
+      message: 'Session not found',
+    },
+    id: null,
+  })
+
+  const missingSession = await fetch(MCP_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+    }),
+  })
+
+  assert.strictEqual(missingSession.status, 400)
+})


### PR DESCRIPTION
Fixes #123.

## Summary

Stateful Streamable HTTP currently returns `400 Bad Request` when a request includes an `mcp-session-id` that does not match a live session. The Streamable HTTP session-management rules use `404 Not Found` as the signal that a client should discard the stale session ID and initialize a new session.

This change returns `404` for unknown stateful session IDs while preserving the existing `400` response for sessionless non-`initialize` requests.

## Changes

- Add an explicit unknown-session branch in the stateful Streamable HTTP POST handler.
- Return JSON-RPC error code `-32001` with `Session not found` for unknown `mcp-session-id` values.
- Preserve the existing malformed-request behavior when no session ID is supplied and the request is not `initialize`.
- Add regression coverage for both response branches.

## Verification

```bash
npm run build
TS_NODE_LOG_ERROR=true npm run test
npm run format:check
```
