### PR TITLE
Add Xquik Streamable HTTP example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ npx -y supergateway \
     --header "X-My-Header: another-header-value"
 ```
 
+For example, connect the hosted [Xquik MCP endpoint](https://docs.xquik.com/mcp/overview) with an API key:
+
+```bash
+npx -y supergateway \
+    --streamableHttp "https://xquik.com/mcp" \
+    --oauth2Bearer "$XQUIK_API_KEY"
+```
+
+Xquik is a hosted proprietary third-party service. It is not affiliated with or endorsed by X Corp.
+
 ## stdio → Streamable HTTP
 
 Expose an MCP stdio server as a Streamable HTTP server.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "supergateway",
   "version": "3.4.3",
-  "description": "Run MCP stdio servers over SSE, Streamable HTTP or visa versa",
+  "description": "Run MCP stdio servers over SSE or Streamable HTTP, or vice versa",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/supercorp-ai/supergateway.git"


### PR DESCRIPTION
## Summary

- Add a Streamable HTTP to stdio example for the hosted Xquik MCP endpoint.
- Demonstrate `--oauth2Bearer` with an API key environment variable.
- Link the Xquik MCP documentation and disclose the hosted proprietary service and X Corp independence.
- Rebuild on current `main` as exactly 1 SSH-signed commit.

## Independent repository fix

Correct the public npm package description from “visa versa” to “vice versa” and clarify the supported SSE and Streamable HTTP directions.

## Validation

- `npm ci` completed successfully.
- `npm run build` passes.
- `npm run format:check` passes.
- The focused Streamable HTTP CLI parser test passes on Node 24.
- The Xquik MCP documentation returns HTTP 200.
- The protected Xquik MCP endpoint returns the expected HTTP 401 without credentials.
- `git diff --check` passes.
- GitHub verifies the 1 public commit's SSH signature.

## Existing test-suite blocker

The full suite reaches 7 files but 6 existing test files fail during `ts-node` type loading before execution. With `TS_NODE_LOG_ERROR=true`, the focused test executes successfully. This documentation and package-description change does not modify runtime or test code.
