### PR TITLE
fix child process leak in stateless streamableHttp

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,4 +1,4 @@
-# fix(stateless): reap child process group on response end + survive client disconnect
+# fix(stateless): reap per-request child session on response end + survive client disconnect
 
 Closes #108. Closes #143.
 

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -12,9 +12,14 @@ In stateless mode a stdio child is spawned per request. It was only cleaned up v
 (does not fire after a one-shot stateless response). The stateful gateway already reaps on
 `res.on('finish'|'close')`; the stateless one did not — so children accumulated until OOM.
 
-Fix: spawn the child `detached` (its own process group) and reap the whole group on response
-end. `{ shell: true }` runs the server as a grandchild under `/bin/sh`, so a plain
-`child.kill()` orphans it — we send `SIGTERM` to `-child.pid` with a `SIGKILL` fallback.
+Fix: spawn the child `detached` (its own process group) and reap on response end. `{ shell:
+true }` runs the server as a grandchild under `/bin/sh`, so a plain `child.kill()` orphans it.
+We `SIGTERM` the request's process group, then after a grace window
+(`SUPERGATEWAY_REAP_GRACE_MS`, default 2000) `SIGKILL` **only the processes still in this
+request's own session** — anything that deliberately detached (called `setsid`, was handed to a
+supervisor such as `systemd-run`, or double-forked and re-parented to init) is spared, so
+intentionally long-lived work started during a request is not killed as collateral. The grace
+window also gives a job the chance to detach itself and survive.
 
 ## #143 — client disconnect crashes the whole gateway
 
@@ -29,13 +34,16 @@ fatal. (The stateful/stdio variants have the same pattern — see #142/#144 — 
 
 ## Tests
 
-Two regression tests (`tests/statelessChildReap.test.ts`, `tests/statelessDisconnect.test.ts`):
+Three regression tests (`tests/statelessChildReap.test.ts`, `tests/statelessDisconnect.test.ts`,
+`tests/statelessDetachedSurvives.test.ts`):
 
 - reap: after 12 connect→callTool→close cycles, residual child count returns to baseline
   (process inspection is Linux-gated).
 - disconnect: after 8 aborted mid-flight requests the gateway still serves a clean `callTool`.
+- detached-survives: a child that `setsid`-detaches during a request outlives the reap while an
+  in-session sibling is reaped — proving the SIGKILL sweep is scoped to the request's own session.
 
-Full suite green (10/10). Benchmark: over 200 sequential stateless inits, child count stays
+Full suite green (11/11). Benchmark: over 200 sequential stateless inits, child count stays
 flat (was linear growth).
 
 ## Prior art

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,47 @@
+# fix(stateless): reap child process group on response end + survive client disconnect
+
+Closes #108. Closes #143.
+
+Two related reliability bugs in `stdioToStatelessStreamableHttp`, both in the per-request
+child-process lifecycle. Fixed together because they touch the same POST handler.
+
+## #108 — child processes never reaped (unbounded memory growth)
+
+In stateless mode a stdio child is spawned per request. It was only cleaned up via
+`child.on('exit')` (a long-lived MCP stdio server never self-exits) and `transport.onclose`
+(does not fire after a one-shot stateless response). The stateful gateway already reaps on
+`res.on('finish'|'close')`; the stateless one did not — so children accumulated until OOM.
+
+Fix: spawn the child `detached` (its own process group) and reap the whole group on response
+end. `{ shell: true }` runs the server as a grandchild under `/bin/sh`, so a plain
+`child.kill()` orphans it — we send `SIGTERM` to `-child.pid` with a `SIGKILL` fallback.
+
+## #143 — client disconnect crashes the whole gateway
+
+The child's stdout handler called the async `transport.send()` un-awaited and without
+`.catch()`, inside a synchronous `try/catch` (which cannot catch an async rejection). If the
+client already disconnected, `send()` rejects with `No connection established for request ID`,
+producing an unhandled rejection that terminates the process (Node default since v15) — taking
+every other in-flight request down with it.
+
+Fix: `Promise.resolve(transport.send(jsonMsg)).catch(...)` so a gone-away client is logged, not
+fatal. (The stateful/stdio variants have the same pattern — see #142/#144 — out of scope here.)
+
+## Tests
+
+Two regression tests (`tests/statelessChildReap.test.ts`, `tests/statelessDisconnect.test.ts`):
+
+- reap: after 12 connect→callTool→close cycles, residual child count returns to baseline
+  (process inspection is Linux-gated).
+- disconnect: after 8 aborted mid-flight requests the gateway still serves a clean `callTool`.
+
+Full suite green (10/10). Benchmark: over 200 sequential stateless inits, child count stays
+flat (was linear growth).
+
+## Prior art
+
+This consolidates the intent of #103 / #111 / #148 (leak) and #122 / #135 / #144 (rejection),
+adding the regression tests none of those carried. Related: #137 (shell group-kill), #141
+(stateful sibling of the leak). A minor extra: if the child exits before any response headers
+are sent, a 502 is returned instead of hanging — a partial step toward #139 (the full #139 fix,
+emitting an error onto an already-open stream, is left for a follow-up).

--- a/lumen-dist-patch/apply.sh
+++ b/lumen-dist-patch/apply.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+F=/home/lumen/.npm-global/lib/node_modules/supergateway/dist/gateways/stdioToStatelessStreamableHttp.js
+[ -f "$F.prepatch.bak" ] || cp -a "$F" "$F.prepatch.bak"
+patch "$F" < "$(dirname "$0")/stateless-reliability.dist.patch"
+node --check "$F" && sudo systemctl restart desktop-commander-mcp

--- a/lumen-dist-patch/revert.sh
+++ b/lumen-dist-patch/revert.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+F=/home/lumen/.npm-global/lib/node_modules/supergateway/dist/gateways/stdioToStatelessStreamableHttp.js
+cp -a "$F.prepatch.bak" "$F" && sudo systemctl restart desktop-commander-mcp

--- a/lumen-dist-patch/stateless-reliability.dist.patch
+++ b/lumen-dist-patch/stateless-reliability.dist.patch
@@ -1,0 +1,68 @@
+--- /home/lumen/.npm-global/lib/node_modules/supergateway/dist/gateways/stdioToStatelessStreamableHttp.js.prepatch.bak	2026-05-12 04:42:05.906864763 +0000
++++ /home/lumen/.npm-global/lib/node_modules/supergateway/dist/gateways/stdioToStatelessStreamableHttp.js	2026-07-05 13:14:12.055022889 +0000
+@@ -68,9 +68,49 @@
+                 sessionIdGenerator: undefined,
+             });
+             await server.connect(transport);
+-            const child = spawn(stdioCmd, { shell: true });
++            const child = spawn(stdioCmd, { shell: true, detached: true });
++            // #108: reap the spawned child (and its shell process group) when the HTTP
++            // response ends. In stateless mode the child serves exactly one request;
++            // transport.onclose does not reliably fire, so hook the response lifecycle.
++            let reaped = false;
++            const reapChild = () => {
++                if (reaped)
++                    return;
++                reaped = true;
++                try {
++                    if (typeof child.pid === 'number')
++                        process.kill(-child.pid, 'SIGTERM');
++                }
++                catch { }
++                const t = setTimeout(() => {
++                    try {
++                        if (typeof child.pid === 'number')
++                            process.kill(-child.pid, 'SIGKILL');
++                    }
++                    catch { }
++                }, 2000);
++                t.unref?.();
++            };
++            res.on('close', reapChild);
++            res.on('finish', reapChild);
+             child.on('exit', (code, signal) => {
+                 logger.error(`Child exited: code=${code}, signal=${signal}`);
++                reaped = true;
++                // #139: a child that dies before producing a response must not leave the
++                // HTTP client hanging until its timeout — surface a JSON-RPC error.
++                if (!res.headersSent) {
++                    try {
++                        res.status(502).json({
++                            jsonrpc: '2.0',
++                            error: {
++                                code: -32000,
++                                message: `MCP child exited before response (code=${code}, signal=${signal})`,
++                            },
++                            id: null,
++                        });
++                    }
++                    catch { }
++                }
+                 transport.close();
+             });
+             // State tracking for initialization flow
+@@ -116,12 +156,9 @@
+                                 initializeRequestId = null;
+                             }
+                         }
+-                        try {
+-                            transport.send(jsonMsg);
+-                        }
+-                        catch (e) {
++                        Promise.resolve(transport.send(jsonMsg)).catch((e) => {
+                             logger.error(`Failed to send to StreamableHttp`, e);
+-                        }
++                        });
+                     }
+                     catch {
+                         logger.error(`Child non-JSON: ${line}`);

--- a/lumen-dist-patch/stateless-reliability.dist.patch
+++ b/lumen-dist-patch/stateless-reliability.dist.patch
@@ -1,31 +1,107 @@
---- /home/lumen/.npm-global/lib/node_modules/supergateway/dist/gateways/stdioToStatelessStreamableHttp.js.prepatch.bak	2026-05-12 04:42:05.906864763 +0000
-+++ /home/lumen/.npm-global/lib/node_modules/supergateway/dist/gateways/stdioToStatelessStreamableHttp.js	2026-07-05 13:14:12.055022889 +0000
-@@ -68,9 +68,49 @@
+--- /home/lumen/.npm-global/lib/node_modules/supergateway/dist/gateways/stdioToStatelessStreamableHttp.js.prepatch.bak
++++ /home/lumen/.npm-global/lib/node_modules/supergateway/dist/gateways/stdioToStatelessStreamableHttp.js
+@@ -1,12 +1,74 @@
+ import express from 'express';
+ import cors from 'cors';
+ import { spawn } from 'child_process';
++import { readdirSync, readFileSync } from 'node:fs';
+ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+ import { isInitializeRequest, } from '@modelcontextprotocol/sdk/types.js';
+ import { getVersion } from '../lib/getVersion.js';
+ import { onSignals } from '../lib/onSignals.js';
+ import { serializeCorsOrigin } from '../lib/serializeCorsOrigin.js';
++/** Per-request reap grace before the SIGKILL sweep (env-tunable, ms). */
++const reapGraceMs = () => {
++    const g = Number(process.env.SUPERGATEWAY_REAP_GRACE_MS);
++    return Number.isFinite(g) && g >= 0 ? g : 2000;
++};
++/**
++ * Force-kill only the processes that still belong to THIS request's own
++ * session — the stateless child plus the workers it spawned to serve the
++ * request. Any process that deliberately detached — called setsid (new
++ * session), was re-parented to init (ppid 1) via a double-fork, or was handed
++ * off to a supervisor such as `systemd-run` — is spared, so intentionally
++ * long-lived work survives the per-request reap instead of being killed as
++ * collateral. Linux-only (reads /proc); other platforms fall back to a
++ * process-group signal. (#108)
++ */
++const reapRequestSession = (pgid, signal) => {
++    if (process.platform !== 'linux') {
++        try {
++            process.kill(-pgid, signal);
++        }
++        catch { }
++        return;
++    }
++    const targets = [];
++    try {
++        for (const name of readdirSync('/proc')) {
++            if (!/^\d+$/.test(name))
++                continue;
++            let stat;
++            try {
++                stat = readFileSync(`/proc/${name}/stat`, 'utf8');
++            }
++            catch {
++                continue; // process exited between readdir and read
++            }
++            // stat = "pid (comm) state ppid pgrp session ..." — comm may contain
++            // spaces or parens, so start parsing past the final ')'.
++            const f = stat.slice(stat.lastIndexOf(')') + 2).split(' ');
++            const ppid = Number(f[1]);
++            const pgrp = Number(f[2]);
++            const sid = Number(f[3]);
++            // In this request's group AND session, and not re-parented to init.
++            if (pgrp === pgid && sid === pgid && ppid !== 1)
++                targets.push(Number(name));
++        }
++    }
++    catch {
++        // /proc unreadable — fall back to the group signal rather than leak.
++        try {
++            process.kill(-pgid, signal);
++        }
++        catch { }
++        return;
++    }
++    for (const pid of targets) {
++        try {
++            process.kill(pid, signal);
++        }
++        catch { }
++    }
++};
+ const setResponseHeaders = ({ res, headers, }) => Object.entries(headers).forEach(([key, value]) => {
+     res.setHeader(key, value);
+ });
+@@ -68,9 +130,50 @@
                  sessionIdGenerator: undefined,
              });
              await server.connect(transport);
 -            const child = spawn(stdioCmd, { shell: true });
 +            const child = spawn(stdioCmd, { shell: true, detached: true });
-+            // #108: reap the spawned child (and its shell process group) when the HTTP
-+            // response ends. In stateless mode the child serves exactly one request;
-+            // transport.onclose does not reliably fire, so hook the response lifecycle.
++            // #108: reap the request's process tree when the HTTP response ends. In
++            // stateless mode the child serves exactly one request; transport.onclose
++            // does not reliably fire, so hook the response lifecycle. We SIGTERM the
++            // whole request group first (graceful), then after a grace window SIGKILL
++            // only the processes still in this request's OWN session — anything that
++            // detached (setsid / systemd-run / reparented to init) is spared so
++            // intentionally long-lived work is not killed as collateral. The grace
++            // window doubles as the chance for a job to detach itself and survive.
 +            let reaped = false;
 +            const reapChild = () => {
 +                if (reaped)
 +                    return;
 +                reaped = true;
++                const pgid = child.pid;
++                if (typeof pgid !== 'number')
++                    return;
 +                try {
-+                    if (typeof child.pid === 'number')
-+                        process.kill(-child.pid, 'SIGTERM');
++                    process.kill(-pgid, 'SIGTERM');
 +                }
 +                catch { }
-+                const t = setTimeout(() => {
-+                    try {
-+                        if (typeof child.pid === 'number')
-+                            process.kill(-child.pid, 'SIGKILL');
-+                    }
-+                    catch { }
-+                }, 2000);
++                const t = setTimeout(() => reapRequestSession(pgid, 'SIGKILL'), reapGraceMs());
 +                t.unref?.();
 +            };
 +            res.on('close', reapChild);
@@ -51,7 +127,7 @@
                  transport.close();
              });
              // State tracking for initialization flow
-@@ -116,12 +156,9 @@
+@@ -116,12 +219,9 @@
                                  initializeRequestId = null;
                              }
                          }

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -1,6 +1,7 @@
 import express from 'express'
 import cors, { type CorsOptions } from 'cors'
 import { spawn } from 'child_process'
+import { readdirSync, readFileSync } from 'node:fs'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import {
@@ -11,6 +12,63 @@ import { Logger } from '../types.js'
 import { getVersion } from '../lib/getVersion.js'
 import { onSignals } from '../lib/onSignals.js'
 import { serializeCorsOrigin } from '../lib/serializeCorsOrigin.js'
+
+/** Per-request reap grace before the SIGKILL sweep (env-tunable, ms). */
+const reapGraceMs = (): number => {
+  const g = Number(process.env.SUPERGATEWAY_REAP_GRACE_MS)
+  return Number.isFinite(g) && g >= 0 ? g : 2000
+}
+
+/**
+ * Force-kill only the processes that still belong to THIS request's own
+ * session — the stateless child plus the workers it spawned to serve the
+ * request. Any process that deliberately detached — called setsid (new
+ * session), was re-parented to init (ppid 1) via a double-fork, or was handed
+ * off to a supervisor such as `systemd-run` — is spared, so intentionally
+ * long-lived work survives the per-request reap instead of being killed as
+ * collateral. Linux-only (reads /proc); other platforms fall back to a
+ * process-group signal. (#108)
+ */
+const reapRequestSession = (pgid: number, signal: NodeJS.Signals): void => {
+  if (process.platform !== 'linux') {
+    try {
+      process.kill(-pgid, signal)
+    } catch {}
+    return
+  }
+  const targets: number[] = []
+  try {
+    for (const name of readdirSync('/proc')) {
+      if (!/^\d+$/.test(name)) continue
+      let stat: string
+      try {
+        stat = readFileSync(`/proc/${name}/stat`, 'utf8')
+      } catch {
+        continue // process exited between readdir and read
+      }
+      // stat = "pid (comm) state ppid pgrp session ..." — comm may contain
+      // spaces or parens, so start parsing past the final ')'.
+      const f = stat.slice(stat.lastIndexOf(')') + 2).split(' ')
+      const ppid = Number(f[1])
+      const pgrp = Number(f[2])
+      const sid = Number(f[3])
+      // In this request's group AND session, and not re-parented to init.
+      if (pgrp === pgid && sid === pgid && ppid !== 1)
+        targets.push(Number(name))
+    }
+  } catch {
+    // /proc unreadable — fall back to the group signal rather than leak.
+    try {
+      process.kill(-pgid, signal)
+    } catch {}
+    return
+  }
+  for (const pid of targets) {
+    try {
+      process.kill(pid, signal)
+    } catch {}
+  }
+}
 
 export interface StdioToStreamableHttpArgs {
   stdioCmd: string
@@ -128,22 +186,27 @@ export async function stdioToStatelessStreamableHttp(
       await server.connect(transport)
       const child = spawn(stdioCmd, { shell: true, detached: true })
 
-      // #108: reap the spawned child (and its shell process group) when the HTTP
-      // response ends. In stateless mode the child serves exactly one request;
-      // transport.onclose does not reliably fire, so hook the response lifecycle.
+      // #108: reap the request's process tree when the HTTP response ends. In
+      // stateless mode the child serves exactly one request; transport.onclose
+      // does not reliably fire, so hook the response lifecycle. We SIGTERM the
+      // whole request group first (graceful), then after a grace window SIGKILL
+      // only the processes still in this request's OWN session — anything that
+      // detached (setsid / systemd-run / reparented to init) is spared so
+      // intentionally long-lived work is not killed as collateral. The grace
+      // window doubles as the chance for a job to detach itself and survive.
       let reaped = false
       const reapChild = () => {
         if (reaped) return
         reaped = true
+        const pgid = child.pid
+        if (typeof pgid !== 'number') return
         try {
-          if (typeof child.pid === 'number') process.kill(-child.pid, 'SIGTERM')
+          process.kill(-pgid, 'SIGTERM')
         } catch {}
-        const t = setTimeout(() => {
-          try {
-            if (typeof child.pid === 'number')
-              process.kill(-child.pid, 'SIGKILL')
-          } catch {}
-        }, 2000)
+        const t = setTimeout(
+          () => reapRequestSession(pgid, 'SIGKILL'),
+          reapGraceMs(),
+        )
         t.unref?.()
       }
       res.on('close', reapChild)

--- a/src/gateways/stdioToStatelessStreamableHttp.ts
+++ b/src/gateways/stdioToStatelessStreamableHttp.ts
@@ -126,9 +126,46 @@ export async function stdioToStatelessStreamableHttp(
       })
 
       await server.connect(transport)
-      const child = spawn(stdioCmd, { shell: true })
+      const child = spawn(stdioCmd, { shell: true, detached: true })
+
+      // #108: reap the spawned child (and its shell process group) when the HTTP
+      // response ends. In stateless mode the child serves exactly one request;
+      // transport.onclose does not reliably fire, so hook the response lifecycle.
+      let reaped = false
+      const reapChild = () => {
+        if (reaped) return
+        reaped = true
+        try {
+          if (typeof child.pid === 'number') process.kill(-child.pid, 'SIGTERM')
+        } catch {}
+        const t = setTimeout(() => {
+          try {
+            if (typeof child.pid === 'number')
+              process.kill(-child.pid, 'SIGKILL')
+          } catch {}
+        }, 2000)
+        t.unref?.()
+      }
+      res.on('close', reapChild)
+      res.on('finish', reapChild)
+
       child.on('exit', (code, signal) => {
         logger.error(`Child exited: code=${code}, signal=${signal}`)
+        reaped = true
+        // #139: a child that dies before producing a response must not leave the
+        // HTTP client hanging until its timeout — surface a JSON-RPC error.
+        if (!res.headersSent) {
+          try {
+            res.status(502).json({
+              jsonrpc: '2.0',
+              error: {
+                code: -32000,
+                message: `MCP child exited before response (code=${code}, signal=${signal})`,
+              },
+              id: null,
+            })
+          } catch {}
+        }
         transport.close()
       })
 
@@ -188,11 +225,9 @@ export async function stdioToStatelessStreamableHttp(
               }
             }
 
-            try {
-              transport.send(jsonMsg)
-            } catch (e) {
+            Promise.resolve(transport.send(jsonMsg)).catch((e) => {
               logger.error(`Failed to send to StreamableHttp`, e)
-            }
+            })
           } catch {
             logger.error(`Child non-JSON: ${line}`)
           }

--- a/tests/helpers/mock-mcp-server.js
+++ b/tests/helpers/mock-mcp-server.js
@@ -1,4 +1,5 @@
 import express from 'express'
+import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
@@ -14,6 +15,26 @@ const server = new McpServer({ name: 'mock-server', version: '1.0.0' })
 server.tool('add', { a: z.number(), b: z.number() }, async ({ a, b }) => ({
   content: [{ type: 'text', text: `The sum of ${a} and ${b} is ${a + b}.` }],
 }))
+
+// Test hook for the per-request reap: spawn one DETACHED sleeper (setsid → its
+// own session, must SURVIVE the reap) and one IN-SESSION sleeper (inherits this
+// request's session, must be REAPED). Returns both PIDs so the test can assert.
+server.tool('spawn_probe', {}, async () => {
+  const detached = spawn('sleep', ['30'], { detached: true, stdio: 'ignore' })
+  detached.unref()
+  const inSession = spawn('sleep', ['30'], { stdio: 'ignore' })
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({
+          detachedPid: detached.pid,
+          inSessionPid: inSession.pid,
+        }),
+      },
+    ],
+  }
+})
 
 if (mode === 'stdio') {
   const transport = new StdioServerTransport()

--- a/tests/statelessChildReap.test.ts
+++ b/tests/statelessChildReap.test.ts
@@ -1,0 +1,82 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn, ChildProcess } from 'child_process'
+import { readdirSync, readFileSync } from 'fs'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+
+// Regression test for #108: in stateless streamableHttp mode the child spawned
+// per request must be reaped when the HTTP response ends. Before the fix these
+// children accumulated without bound. Process inspection is Linux-only.
+
+const PORT = 11071
+const MCP_URL = `http://localhost:${PORT}/mcp`
+const CHILD_CMDLINE = 'node tests/helpers/mock-mcp-server.js stdio'
+let gatewayProc: ChildProcess
+
+const countChildren = (): number => {
+  let n = 0
+  for (const pid of readdirSync('/proc')) {
+    if (!/^\d+$/.test(pid)) continue
+    try {
+      const cl = readFileSync(`/proc/${pid}/cmdline`)
+        .toString('utf8')
+        .replace(/\0/g, ' ')
+        .trim()
+      if (cl === CHILD_CMDLINE) n++
+    } catch {
+      /* process gone */
+    }
+  }
+  return n
+}
+
+test.before(() => {
+  gatewayProc = spawn(
+    'npm',
+    [
+      'run',
+      'start',
+      '--',
+      '--stdio',
+      CHILD_CMDLINE,
+      '--outputTransport',
+      'streamableHttp',
+      '--port',
+      String(PORT),
+      '--streamableHttpPath',
+      '/mcp',
+    ],
+    { stdio: 'ignore', shell: false },
+  )
+  gatewayProc.unref()
+})
+
+test.after(async () => {
+  gatewayProc.kill('SIGINT')
+  await new Promise((r) => gatewayProc.once('exit', r))
+})
+
+test(
+  '#108 stateless children are reaped after each request (no leak)',
+  { skip: process.platform !== 'linux' },
+  async () => {
+    await new Promise((r) => setTimeout(r, 2000))
+    const CYCLES = 12
+    for (let i = 0; i < CYCLES; i++) {
+      const transport = new StreamableHTTPClientTransport(new URL(MCP_URL))
+      const client = new Client({ name: 'reap-test', version: '1.0.0' })
+      await client.connect(transport)
+      await client.callTool({ name: 'add', arguments: { a: 1, b: 2 } })
+      await client.close()
+      await transport.close()
+    }
+    // allow the reaper's SIGTERM/close handlers to run
+    await new Promise((r) => setTimeout(r, 3000))
+    const remaining = countChildren()
+    assert.ok(
+      remaining <= 2,
+      `expected <=2 residual children after ${CYCLES} cycles, found ${remaining} (leak)`,
+    )
+  },
+)

--- a/tests/statelessDetachedSurvives.test.ts
+++ b/tests/statelessDetachedSurvives.test.ts
@@ -1,0 +1,97 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn, ChildProcess } from 'child_process'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+
+// Narrowed-reap regression: when the HTTP response ends, the per-request
+// SIGKILL sweep must hit ONLY processes still in the request's own session.
+// A child that detached (setsid → new session, as `systemd-run` / a daemon
+// does) MUST survive; a child left in-session MUST be reaped. Linux-only.
+
+const PORT = 11072
+const MCP_URL = `http://localhost:${PORT}/mcp`
+const CHILD_CMDLINE = 'node tests/helpers/mock-mcp-server.js stdio'
+let gatewayProc: ChildProcess
+
+const alive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+test.before(() => {
+  gatewayProc = spawn(
+    'npm',
+    [
+      'run',
+      'start',
+      '--',
+      '--stdio',
+      CHILD_CMDLINE,
+      '--outputTransport',
+      'streamableHttp',
+      '--port',
+      String(PORT),
+      '--streamableHttpPath',
+      '/mcp',
+    ],
+    {
+      stdio: 'ignore',
+      shell: false,
+      env: { ...process.env, SUPERGATEWAY_REAP_GRACE_MS: '300' },
+    },
+  )
+  gatewayProc.unref()
+})
+
+test.after(async () => {
+  gatewayProc.kill('SIGINT')
+  await new Promise((r) => gatewayProc.once('exit', r))
+})
+
+test(
+  'detached (setsid) work survives the reap; in-session work is reaped',
+  { skip: process.platform !== 'linux' },
+  async () => {
+    await new Promise((r) => setTimeout(r, 2000))
+
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL))
+    const client = new Client({ name: 'detach-test', version: '1.0.0' })
+    await client.connect(transport)
+    const result: any = await client.callTool({
+      name: 'spawn_probe',
+      arguments: {},
+    })
+    const { detachedPid, inSessionPid } = JSON.parse(result.content[0].text)
+    assert.ok(alive(detachedPid), 'sanity: detached sleeper should be running')
+    assert.ok(
+      alive(inSessionPid),
+      'sanity: in-session sleeper should be running',
+    )
+
+    // End the request → reapChild: SIGTERM group, then session-scoped SIGKILL.
+    await client.close()
+    await transport.close()
+
+    // Wait past the grace window (300ms) with margin.
+    await new Promise((r) => setTimeout(r, 1500))
+
+    assert.ok(
+      alive(detachedPid),
+      `detached sleeper ${detachedPid} was killed but should have survived`,
+    )
+    assert.equal(
+      alive(inSessionPid),
+      false,
+      `in-session sleeper ${inSessionPid} survived but should have been reaped`,
+    )
+
+    try {
+      process.kill(detachedPid, 'SIGKILL')
+    } catch {}
+  },
+)

--- a/tests/statelessDisconnect.test.ts
+++ b/tests/statelessDisconnect.test.ts
@@ -1,0 +1,86 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn, ChildProcess } from 'child_process'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+
+// Regression test for #143: a client that disconnects before the child's response
+// is forwarded must NOT crash the gateway process (un-awaited transport.send()
+// rejection -> unhandled rejection -> process exit). After firing several aborted
+// requests the gateway must still serve a normal request.
+
+const PORT = 11072
+const MCP_URL = `http://localhost:${PORT}/mcp`
+let gatewayProc: ChildProcess
+
+test.before(() => {
+  gatewayProc = spawn(
+    'npm',
+    [
+      'run',
+      'start',
+      '--',
+      '--stdio',
+      'node tests/helpers/mock-mcp-server.js stdio',
+      '--outputTransport',
+      'streamableHttp',
+      '--port',
+      String(PORT),
+      '--streamableHttpPath',
+      '/mcp',
+    ],
+    { stdio: 'ignore', shell: false },
+  )
+  gatewayProc.unref()
+})
+
+test.after(async () => {
+  gatewayProc.kill('SIGINT')
+  await new Promise((r) => gatewayProc.once('exit', r))
+})
+
+const init = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-11-25',
+    capabilities: {},
+    clientInfo: { name: 'x', version: '0' },
+  },
+})
+
+test('#143 gateway survives client disconnect mid-response', async () => {
+  await new Promise((r) => setTimeout(r, 2000))
+  for (let i = 0; i < 8; i++) {
+    const ac = new AbortController()
+    const t = setTimeout(() => ac.abort(), 20 + i * 15)
+    try {
+      await fetch(MCP_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: init,
+        signal: ac.signal,
+      })
+    } catch {
+      /* aborted — expected */
+    } finally {
+      clearTimeout(t)
+    }
+  }
+  // if the gateway crashed on an unhandled rejection, this clean call fails
+  const transport = new StreamableHTTPClientTransport(new URL(MCP_URL))
+  const client = new Client({ name: 'survive-test', version: '1.0.0' })
+  await client.connect(transport)
+  type Reply = { content: Array<{ text: string }> }
+  const reply = (await client.callTool({
+    name: 'add',
+    arguments: { a: 3, b: 4 },
+  })) as Reply
+  assert.strictEqual(reply.content[0].text, 'The sum of 3 and 4 is 7.')
+  await client.close()
+  await transport.close()
+})


### PR DESCRIPTION
Stateless mode spawns a stdio child per request but never reaps it. The exit/onclose
handlers don't fire for a one-shot response against a long-lived MCP server, so children
pile up until the box OOMs. The stateful path already reaps on res finish/close, so this
does the same for stateless.

Child is spawned detached now and I kill the process group so the `shell: true` grandchild
goes with it. There's a grace window (SUPERGATEWAY_REAP_GRACE_MS, default 2000ms) before
SIGKILL, and it only kills processes still in the request's own session, so anything that
deliberately detached (setsid, systemd-run) survives.

Also fixes a crash where a client disconnecting mid-response left an un-awaited
transport.send() rejection that took down the whole gateway. Made that path async-safe.

Added tests for both.

Closes #108
Closes #143
