### PR TITLE
Fix #141: reap stdio child process group on stateful session close

### DIFF
--- a/src/gateways/stdioToStatefulStreamableHttp.ts
+++ b/src/gateways/stdioToStatefulStreamableHttp.ts
@@ -122,6 +122,13 @@ export async function stdioToStatefulStreamableHttp(
     } else if (!sessionId && isInitializeRequest(req.body)) {
       // New initialization request
 
+      // Bind the session identity and cleanup state in this closure at
+      // spawn/session-creation time. The transport can report
+      // transport.sessionId === undefined at close time (see issue #141 logs),
+      // so session cleanup must NOT be gated on transport.sessionId being set.
+      let boundSessionId: string | undefined
+      let cleanedUp = false
+
       const server = new Server(
         { name: 'supergateway', version: getVersion() },
         { capabilities: {} },
@@ -130,16 +137,69 @@ export async function stdioToStatefulStreamableHttp(
       transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (sessionId) => {
-          // Store the transport by session ID
+          // Bind and store the transport by session ID
+          boundSessionId = sessionId
           transports[sessionId] = transport
           // Initialize session access count
           sessionCounter?.inc(sessionId, 'session initialization')
         },
       })
       await server.connect(transport)
-      const child = spawn(stdioCmd, { shell: true })
+
+      // Spawn the stdio child in its OWN process group (detached: true) while
+      // keeping shell: true for command compatibility. This is the crux of the
+      // #141 fix: with shell: true the spawned child is a `sh -c` wrapper, so a
+      // plain child.kill() only SIGTERMs that wrapper. On dash/ash
+      // (node:*-slim, alpine) the wrapper exits WITHOUT forwarding the signal,
+      // orphaning the real MCP process while logging a clean-looking
+      // `Child exited: signal=SIGTERM`. Signalling the whole process group
+      // (negative PID) reaps the entire tree regardless of the shell's
+      // signal-forwarding behaviour.
+      const child = spawn(stdioCmd, { shell: true, detached: true })
+
+      const killChildGroup = () => {
+        if (child.pid === undefined) return
+        // Signal the child's WHOLE process group (negative PID). We do this even
+        // when the tracked child (the `sh -c` wrapper) has already exited: on
+        // shells that don't forward signals and exit first — e.g. busybox ash
+        // (alpine) — the real MCP process and anything it spawned are still
+        // alive in the group and would otherwise orphan (issue #141). A process
+        // group remains signalable while any member is alive.
+        try {
+          process.kill(-child.pid, 'SIGTERM')
+        } catch {
+          // Whole group already gone (ESRCH) or the platform rejected the group
+          // signal; fall back to a direct kill and ignore if it too is gone.
+          try {
+            child.kill('SIGTERM')
+          } catch {
+            /* already dead — nothing to do */
+          }
+        }
+      }
+
+      // Single idempotent cleanup path. Transport close, transport error,
+      // session timeout and the child's own exit handler can all fire for one
+      // session; the guard ensures we never double-signal a dead group or
+      // double-delete the transport entry.
+      const cleanupSession = (reason: string) => {
+        if (cleanedUp) return
+        cleanedUp = true
+
+        if (boundSessionId) {
+          sessionCounter?.clear(boundSessionId, false, reason)
+          delete transports[boundSessionId]
+        }
+
+        logger.info(
+          `Killing child process group for session ${boundSessionId ?? '(uninitialized)'}: ${reason}`,
+        )
+        killChildGroup()
+      }
+
       child.on('exit', (code, signal) => {
         logger.error(`Child exited: code=${code}, signal=${signal}`)
+        cleanupSession('child process exited')
         transport.close()
       })
 
@@ -174,29 +234,18 @@ export async function stdioToStatefulStreamableHttp(
       }
 
       transport.onclose = () => {
-        logger.info(`StreamableHttp connection closed (session ${sessionId})`)
-        if (transport.sessionId) {
-          sessionCounter?.clear(
-            transport.sessionId,
-            false,
-            'transport being closed',
-          )
-          delete transports[transport.sessionId]
-        }
-        child.kill()
+        logger.info(
+          `StreamableHttp connection closed (session ${boundSessionId ?? '(uninitialized)'})`,
+        )
+        cleanupSession('transport being closed')
       }
 
       transport.onerror = (err) => {
-        logger.error(`StreamableHttp error (session ${sessionId}):`, err)
-        if (transport.sessionId) {
-          sessionCounter?.clear(
-            transport.sessionId,
-            false,
-            'transport emitting error',
-          )
-          delete transports[transport.sessionId]
-        }
-        child.kill()
+        logger.error(
+          `StreamableHttp error (session ${boundSessionId ?? '(uninitialized)'}):`,
+          err,
+        )
+        cleanupSession('transport emitting error')
       }
     } else {
       // Invalid request

--- a/tests/helpers/mock-mcp-server.js
+++ b/tests/helpers/mock-mcp-server.js
@@ -5,9 +5,28 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { z } from 'zod'
+import { spawn as spawnChild } from 'node:child_process'
 
 const mode = process.argv[2]
 const port = Number(process.env.PORT || 3000)
+
+// Opt-in for the process-lifecycle repro test (issue #141). Spawn a descendant
+// that stays in the same process group but is NOT the gateway's direct kill
+// target, and have it record its own PID. A single-process child.kill() (pre-
+// fix) never reaches this grandchild, so it orphans; a process-group kill
+// (post-fix) reaps it. Shell-independent — does not rely on any signal-
+// forwarding or exec-optimization behaviour of the intermediate shell.
+// No effect unless LEAK_PID_FILE is set.
+if (process.env.LEAK_PID_FILE) {
+  spawnChild(
+    process.execPath,
+    [
+      '-e',
+      "require('fs').writeFileSync(process.env.LEAK_PID_FILE, String(process.pid)); setInterval(() => {}, 1 << 30)",
+    ],
+    { stdio: 'ignore', env: process.env },
+  )
+}
 
 const server = new McpServer({ name: 'mock-server', version: '1.0.0' })
 

--- a/tests/stdioToStatefulStreamableHttp.processLifecycle.test.ts
+++ b/tests/stdioToStatefulStreamableHttp.processLifecycle.test.ts
@@ -1,0 +1,161 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn, ChildProcess } from 'child_process'
+import { readFileSync, existsSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+
+/**
+ * Regression test for issue #141: in --stateful streamableHttp mode the stdio
+ * child (and its whole process tree) must be reaped when its session closes.
+ *
+ * The bug composes two halves:
+ *   1. Close-path cleanup gated on transport.sessionId (undefined at close).
+ *   2. spawn(cmd, { shell: true }) => a `sh -c` wrapper; a plain child.kill()
+ *      signals only ONE process. Any descendants (the wrapper's real MCP child,
+ *      or grandchildren that MCP server spawns) are not signalled and orphan.
+ *      On dash/ash the wrapper itself is the survivor; but the general defect
+ *      is that a single-PID kill cannot reap a process tree.
+ *
+ * We reproduce this shell-independently: the stdio MCP server spawns a
+ * descendant "worker" (see tests/helpers/mock-mcp-server.js, gated on
+ * LEAK_PID_FILE) that stays in the same process group and records its own PID.
+ * A single-process child.kill() (pre-fix) never reaches that grandchild, so it
+ * survives the session's close. The post-fix gateway spawns detached and
+ * signals the whole process group (negative PID), reaping the entire tree
+ * regardless of shell signal-forwarding or exec-optimization behaviour.
+ *
+ * Liveness is checked directly via process.kill(pid, 0) — no pgrep/procps
+ * dependency.
+ */
+
+const PORT = 11007
+const MCP_URL = `http://localhost:${PORT}/mcp`
+const PID_FILE = join(tmpdir(), `supergateway-141-${randomUUID()}.pid`)
+
+const STDIO_CMD = `node tests/helpers/mock-mcp-server.js stdio`
+
+let gatewayProc: ChildProcess
+
+const isAlive = (pid: number): boolean => {
+  // A zombie (killed but not yet reaped) still answers kill(pid, 0). That can
+  // happen when the reaper is absent — e.g. the test runs as PID 1 in a bare
+  // container. Treat a zombie as gone by checking /proc state on Linux; on
+  // platforms without /proc (macOS), kill(pid, 0) is authoritative.
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf8')
+    const state = stat.slice(stat.lastIndexOf(')') + 2).split(' ')[0]
+    return state !== 'Z'
+  } catch {
+    if (existsSync('/proc/self')) return false // Linux: no /proc/<pid> => gone
+  }
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+test.before(() => {
+  // Spawn the BUILT entrypoint directly (node dist/index.js), the way the
+  // supergateway image runs in production — NOT via `npm run start`. npm runs
+  // lifecycle scripts in their own process group and reaps that group on exit,
+  // which would mask the very orphan this test asserts against. Requires a
+  // prior `npm run build`, consistent with the rest of the suite (which runs
+  // the built code through `npm run start`) and with AGENTS.md.
+  gatewayProc = spawn(
+    process.execPath,
+    [
+      'dist/index.js',
+      '--stdio',
+      STDIO_CMD,
+      '--outputTransport',
+      'streamableHttp',
+      '--stateful',
+      '--port',
+      String(PORT),
+      '--streamableHttpPath',
+      '/mcp',
+    ],
+    {
+      stdio: 'ignore',
+      shell: false,
+      env: { ...process.env, LEAK_PID_FILE: PID_FILE },
+    },
+  )
+  gatewayProc.unref()
+})
+
+test.after(async () => {
+  // Best-effort: reap the recorded child if a (pre-fix) failure left it alive,
+  // so a failing run does not leave orphans behind.
+  try {
+    if (existsSync(PID_FILE)) {
+      const pid = Number(readFileSync(PID_FILE, 'utf8').trim())
+      if (Number.isInteger(pid) && isAlive(pid)) {
+        try {
+          process.kill(pid, 'SIGKILL')
+        } catch {
+          /* already gone */
+        }
+      }
+    }
+  } finally {
+    rmSync(PID_FILE, { force: true })
+  }
+
+  gatewayProc.kill('SIGINT')
+  await new Promise((resolve) => gatewayProc.once('exit', resolve))
+})
+
+test('stateful session close reaps the spawned stdio child (issue #141)', async () => {
+  const transport = new StreamableHTTPClientTransport(new URL(MCP_URL))
+  const client = new Client({ name: 'lifecycle-test', version: '1.0.0' })
+  await new Promise((r) => setTimeout(r, 2000))
+  await client.connect(transport)
+  assert.ok(transport.sessionId, 'sessionId should be set after connect')
+
+  // The MCP server spawns a descendant worker that writes its PID; wait for it.
+  let childPid = 0
+  for (let i = 0; i < 50 && childPid === 0; i++) {
+    if (existsSync(PID_FILE)) {
+      const raw = readFileSync(PID_FILE, 'utf8').trim()
+      if (raw) childPid = Number(raw)
+    }
+    if (childPid === 0) await new Promise((r) => setTimeout(r, 100))
+  }
+  assert.ok(
+    Number.isInteger(childPid) && childPid > 0,
+    'spawned MCP child should have recorded its PID',
+  )
+  assert.ok(
+    isAlive(childPid),
+    `spawned child (pid ${childPid}) should be alive while the session is open`,
+  )
+
+  // Close the session — this drives the gateway's transport-close cleanup path.
+  await transport.terminateSession()
+  assert.strictEqual(transport.sessionId, undefined)
+  await client.close()
+  transport.close()
+
+  // Post-fix: the whole process group is signalled, so the descendant worker
+  // exits. Pre-fix: a single-PID child.kill() never reaches it and it orphans.
+  let gone = false
+  for (let i = 0; i < 50 && !gone; i++) {
+    if (!isAlive(childPid)) {
+      gone = true
+      break
+    }
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  assert.ok(
+    gone,
+    `spawned child (pid ${childPid}) must be reaped after the session closes; ` +
+      `still alive => orphaned stdio process (issue #141 leak)`,
+  )
+})


### PR DESCRIPTION
In --stateful streamableHttp mode the spawned stdio child could orphan when its session closed. Two composed causes:

1. Close-path cleanup (session-counter clear + transports delete) was gated on transport.sessionId, which the transport can report as undefined at close time (per the issue's logs), so cleanup was skipped.
2. spawn(cmd, { shell: true }) makes the child a `sh -c` wrapper. A plain child.kill() signals only that one process; on dash/ash (node:*-slim, alpine) the wrapper exits WITHOUT forwarding the signal and the real MCP process (plus anything it spawned) orphans, while the logs show a clean-looking `Child exited: signal=SIGTERM`.

Fix (process-group approach, as committed on the issue thread):
- spawn with detached: true (keeping shell: true) so the child leads its own process group;
- kill via process.kill(-child.pid, 'SIGTERM') to reap the whole tree, with a child.kill() fallback if the group signal throws. The group is signalled even after the tracked wrapper has exited, since descendants can still be alive in the group (this is what alpine/ash needs);
- bind the session id (and child handle) in the close-handler closure at session-creation time, so cleanup no longer depends on transport.sessionId;
- route close/error/timeout/child-exit through one idempotent cleanupSession() guarded by a per-session flag, so nothing double-signals a dead group or double-deletes the transport.

Scope: stateful gateway only; the stateless gateway (PR #151's lane) is untouched. Relates to observations in #108/#111/#124, which added child.kill() on other paths but inherit the shell-wrapper gap.

Adds tests/stdioToStatefulStreamableHttp.processLifecycle.test.ts: a shell-independent regression that spawns a descendant which a single-PID kill cannot reach and asserts it is reaped on session close. Fails on the pre-fix gateway, passes after. Verified on macOS, debian-slim (dash) and alpine (ash).