### PR TITLE
fix: close existing transport before SSE reconnect (#112 #153)

### DIFF
--- a/src/gateways/stdioToSse.ts
+++ b/src/gateways/stdioToSse.ts
@@ -112,6 +112,11 @@ export async function stdioToSse(args: StdioToSseArgs) {
     })
 
     const sseTransport = new SSEServerTransport(`${baseUrl}${messagePath}`, res)
+    // Close any existing transport before connecting to avoid
+    // "Already connected to a transport" error on SSE reconnect
+    if (server.transport) {
+      await server.close()
+    }
     await server.connect(sseTransport)
 
     const sessionId = sseTransport.sessionId


### PR DESCRIPTION
## Problem

When the SSE client reconnects to supergateway, `server.connect()` is called on a `Server` instance that may still reference the previous SSE transport. The MCP SDK throws:

```
Error: Already connected to a transport. Call close() before connecting to a new transport
```

Closes #112, #153

## Root Cause

`stdioToSse.ts` creates a single `Server` instance and calls `server.connect()` on every new SSE connection. The MCP SDK's `Protocol.connect()` checks `this._transport` — if already set (previous connection not fully torn down), it throws.

## Fix

Check `server.transport` before connecting. If an existing transport is found, close it first. MCP SDK's `close()` cleans up properly (`_onclose()` sets `this._transport = undefined`), so subsequent `connect()` succeeds.

## Testing

- Existing test suite should pass (no API change)
- Verified with Hermes agent: SSE reconnect no longer crashes