### PR TITLE
Return 404 for an unknown mcp-session-id in stateful streamableHttp

### DIFF
--- a/src/gateways/stdioToStatefulStreamableHttp.ts
+++ b/src/gateways/stdioToStatefulStreamableHttp.ts
@@ -198,8 +198,30 @@ export async function stdioToStatefulStreamableHttp(
         }
         child.kill()
       }
+    } else if (sessionId) {
+      // The client sent a session id we no longer hold: the session was
+      // terminated, reaped by --sessionTimeout, or lost across a restart.
+      // The MCP spec requires 404 here, and that 404 is the signal that makes
+      // a compliant client start a new session:
+      //
+      //   "The server MAY terminate the session at any time, after which it
+      //    MUST respond to requests containing that session ID with HTTP 404
+      //    Not Found. When a client receives HTTP 404 in response to a request
+      //    containing an Mcp-Session-Id, it MUST start a new session by
+      //    sending a new InitializeRequest without a session ID attached."
+      //
+      // Answering 400 instead leaves the client stuck replaying a dead id.
+      res.status(404).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32001,
+          message: 'Session not found',
+        },
+        id: null,
+      })
+      return
     } else {
-      // Invalid request
+      // Invalid request: no session id, and not an initialize request.
       res.status(400).json({
         jsonrpc: '2.0',
         error: {
@@ -234,8 +256,14 @@ export async function stdioToStatefulStreamableHttp(
     res: express.Response,
   ) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined
-    if (!sessionId || !transports[sessionId]) {
+    if (!sessionId) {
       res.status(400).send('Invalid or missing session ID')
+      return
+    }
+    if (!transports[sessionId]) {
+      // Unknown session id -> 404, so the client re-initializes rather than
+      // retrying a dead id. See the POST handler above for the spec citation.
+      res.status(404).send('Session not found')
       return
     }
 

--- a/tests/stdioToStatefulStreamableHttp.test.ts
+++ b/tests/stdioToStatefulStreamableHttp.test.ts
@@ -68,3 +68,51 @@ test('stdioToStatefulStreamableHttp listTools and callTool', async () => {
   await client.close()
   transport.close()
 })
+
+test('stdioToStatefulStreamableHttp session-id status codes', async () => {
+  const JSON_HEADERS = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+  }
+  const toolsList = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'tools/list',
+    params: {},
+  })
+  const UNKNOWN_SESSION = '00000000-0000-4000-8000-000000000000'
+
+  // A session id the gateway does not hold must be 404, not 400. Per the MCP
+  // Streamable HTTP spec a client MUST re-initialize on 404, and that is the
+  // only signal it gets; a 400 leaves it replaying a dead id forever.
+  const postUnknown = await fetch(MCP_URL, {
+    method: 'POST',
+    headers: { ...JSON_HEADERS, 'mcp-session-id': UNKNOWN_SESSION },
+    body: toolsList,
+  })
+  assert.strictEqual(postUnknown.status, 404, 'POST with unknown session id')
+
+  const getUnknown = await fetch(MCP_URL, {
+    method: 'GET',
+    headers: { Accept: 'text/event-stream', 'mcp-session-id': UNKNOWN_SESSION },
+  })
+  assert.strictEqual(getUnknown.status, 404, 'GET with unknown session id')
+  await getUnknown.body?.cancel()
+
+  // The other direction: a genuinely absent header is still a 400. Without
+  // this case the change above could be satisfied by returning 404 for
+  // everything, which would be a different spec violation.
+  const postMissing = await fetch(MCP_URL, {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: toolsList,
+  })
+  assert.strictEqual(postMissing.status, 400, 'POST with no session id')
+
+  const getMissing = await fetch(MCP_URL, {
+    method: 'GET',
+    headers: { Accept: 'text/event-stream' },
+  })
+  assert.strictEqual(getMissing.status, 400, 'GET with no session id')
+  await getMissing.body?.cancel()
+})


### PR DESCRIPTION
Fixes #123.

## The problem

In `--stateful` streamableHttp mode, both request handlers answer **400** when a request carries an `mcp-session-id` that no longer maps to a live entry in `transports`. The MCP Streamable HTTP spec requires **404** there:

> The server MAY terminate the session at any time, after which it MUST respond to requests containing that session ID with HTTP 404 Not Found. When a client receives HTTP 404 in response to a request containing an `Mcp-Session-Id`, it MUST start a new session by sending a new `InitializeRequest` without a session ID attached.

Both clauses are MUST, and the 404 is the *only* signal that triggers a client's re-initialize path. Because supergateway returns 400, a compliant client cannot distinguish "you forgot the header" from "your session is gone" — so it keeps replaying the dead id, and every call fails identically until a human restarts it.

Two sites collapse the two conditions into one status:

- the POST handler's final `else`, reached both when `sessionId` is absent and when it is present but unknown;
- `handleSessionRequest` (GET/DELETE), whose `!sessionId || !transports[sessionId]` guard does the same for the long-lived SSE stream.

## The change

Split each check so the two conditions get their correct status. An absent header still returns 400; an unknown id now returns 404. No lifecycle or session-accounting logic is touched.

## Why it matters in practice

Observed against supergateway 3.4.3 bridging a stdio MCP server behind an MCP gateway. `--sessionTimeout` reaps a session once its access count reaches zero; the gateway had cached the session id and, on the resulting 400, never re-initialized. The upstream server became unreachable from the first reap until the gateway process itself was restarted — while the container stayed healthy and passed its healthcheck, so nothing looked broken.

Raising `--sessionTimeout` only widens the window. With this change the client is told to re-initialize and recovers on its own; verified by recreating the container mid-session and watching the client reconnect without intervention.

## Tests

Adds a case to `tests/stdioToStatefulStreamableHttp.test.ts` asserting all four combinations: POST and GET, each with an unknown session id (404) and with no session id at all (400).

The 400 assertions are deliberate. Without them the test would also pass for an implementation that returned 404 unconditionally, which is a different spec violation.

Verified load-bearing by running the suite both ways:

```
WITH the fix:     # tests 9  # pass 9  # fail 0
WITHOUT the fix:  not ok 5 - stdioToStatefulStreamableHttp session-id status codes
                    expected: 404
                    actual:   400
                  # tests 9  # pass 8  # fail 1
```

One note for anyone reproducing that: `npm start` runs `dist/index.js` and there is no `pretest` hook, so the suite exercises the compiled output. Reverting the `.ts` without rebuilding leaves the previous `dist/` in place and the test passes misleadingly — each arm above was rebuilt.

Full suite passes: 9/9.
